### PR TITLE
에이전트 도구 실행 결과 구조화 (ToolResult)

### DIFF
--- a/src/main/java/com/aicsassistant/analysis/agent/AgentTool.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/AgentTool.java
@@ -9,5 +9,5 @@ public interface AgentTool {
     /** One-line description shown to the LLM in the system prompt. */
     String description();
 
-    String execute(JsonNode input);
+    ToolResult execute(JsonNode input);
 }

--- a/src/main/java/com/aicsassistant/analysis/agent/InquiryAgentService.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/InquiryAgentService.java
@@ -94,16 +94,20 @@ public class InquiryAgentService {
             JsonNode actionInput = node.path("actionInput");
 
             AgentTool tool = resolveTool(tools, action);
-            String observation;
+            ToolResult toolResult;
             try {
-                observation = tool.execute(actionInput);
+                toolResult = tool.execute(actionInput);
             } catch (Exception e) {
-                observation = "Tool execution error: " + e.getMessage();
+                toolResult = ToolResult.error(
+                        ToolErrorCategory.TRANSIENT,
+                        true,
+                        "Tool execution failed: " + e.getMessage());
                 log.warn("[Agent inquiryId={} step={}] tool error action={}", inquiry.getId(), step, action, e);
             }
 
-            log.info("[Agent inquiryId={} step={}] action={} observation_len={}",
-                    inquiry.getId(), step, action, observation.length());
+            String observation = serializeObservation(toolResult);
+            log.info("[Agent inquiryId={} step={}] action={} ok={} category={} observation_len={}",
+                    inquiry.getId(), step, action, toolResult.ok(), toolResult.errorCategory(), observation.length());
 
             // search_manual 스텝에는 이번 호출에서 가져온 문서 목록을 첨부
             List<RetrievedManualChunkDto> stepChunks = (tool instanceof SearchManualTool s) ? s.getLastCallChunks() : List.of();
@@ -124,8 +128,12 @@ public class InquiryAgentService {
         if (orderId != null && !orderId.isBlank()) {
             try {
                 JsonNode orderInput = objectMapper.createObjectNode().put("orderId", orderId);
-                String orderInfo = orderTool.execute(orderInput);
-                sb.append("[관련 주문 정보]\n").append(orderInfo).append("\n");
+                ToolResult orderResult = orderTool.execute(orderInput);
+                if (orderResult.ok()) {
+                    sb.append("[관련 주문 정보]\n").append(orderResult.data()).append("\n");
+                } else {
+                    sb.append("[관련 주문 조회 실패] ").append(orderResult.errorMessage()).append("\n");
+                }
             } catch (Exception e) {
                 log.warn("[Agent] 주문 정보 선주입 실패 orderId={}", orderId, e);
             }
@@ -133,6 +141,15 @@ public class InquiryAgentService {
 
         sb.append("[문의 내용]\n").append(inquiry.getContent());
         return sb.toString();
+    }
+
+    private String serializeObservation(ToolResult result) {
+        try {
+            return objectMapper.writeValueAsString(result);
+        } catch (Exception e) {
+            return "{\"ok\":false,\"errorCategory\":\"TRANSIENT\",\"isRetryable\":true,"
+                    + "\"errorMessage\":\"Failed to serialize tool result\"}";
+        }
     }
 
     private AgentTool resolveTool(List<AgentTool> tools, String name) {

--- a/src/main/java/com/aicsassistant/analysis/agent/ToolErrorCategory.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/ToolErrorCategory.java
@@ -1,0 +1,15 @@
+package com.aicsassistant.analysis.agent;
+
+/**
+ * 도구 실행 실패 유형. LLM이 다음 행동(재시도/입력수정/에스컬레이션)을 결정하는 단서로 사용한다.
+ */
+public enum ToolErrorCategory {
+    /** 일시적 외부 장애. 짧은 시간 후 같은 입력으로 재시도 가능. */
+    TRANSIENT,
+    /** 입력 형식/필수값 오류. LLM이 actionInput을 수정해 다시 호출해야 함. */
+    VALIDATION,
+    /** 권한 부족. 자동 재시도 금지. 상담사 에스컬레이션 신호로 사용. */
+    PERMISSION,
+    /** 요청한 리소스가 존재하지 않음. 같은 입력으로 재시도해도 결과 동일. */
+    NOT_FOUND
+}

--- a/src/main/java/com/aicsassistant/analysis/agent/ToolResult.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/ToolResult.java
@@ -1,0 +1,23 @@
+package com.aicsassistant.analysis.agent;
+
+/**
+ * 도구 실행 결과. 성공 시 {@code data}만, 실패 시 {@code errorCategory}/{@code isRetryable}/{@code errorMessage}만 채워진다.
+ *
+ * <p>LLM에게 전달될 때는 JSON으로 직렬화되어 에이전트가 에러 유형에 맞는 다음 행동을 선택할 수 있다.
+ */
+public record ToolResult(
+        boolean ok,
+        String data,
+        ToolErrorCategory errorCategory,
+        boolean isRetryable,
+        String errorMessage
+) {
+
+    public static ToolResult success(String data) {
+        return new ToolResult(true, data, null, false, null);
+    }
+
+    public static ToolResult error(ToolErrorCategory category, boolean retryable, String message) {
+        return new ToolResult(false, null, category, retryable, message);
+    }
+}

--- a/src/main/java/com/aicsassistant/analysis/agent/tool/CheckOrderStatusTool.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/tool/CheckOrderStatusTool.java
@@ -1,6 +1,8 @@
 package com.aicsassistant.analysis.agent.tool;
 
 import com.aicsassistant.analysis.agent.AgentTool;
+import com.aicsassistant.analysis.agent.ToolErrorCategory;
+import com.aicsassistant.analysis.agent.ToolResult;
 import com.aicsassistant.order.InMemoryOrderRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -29,13 +31,20 @@ public class CheckOrderStatusTool implements AgentTool {
     }
 
     @Override
-    public String execute(JsonNode input) {
+    public ToolResult execute(JsonNode input) {
         String orderId = input.path("orderId").asText("").strip();
         if (orderId.isBlank()) {
-            return "Error: 'orderId' field is required.";
+            return ToolResult.error(
+                    ToolErrorCategory.VALIDATION,
+                    false,
+                    "'orderId' field is required.");
         }
         return orderRepository.findById(orderId)
-                .map(orderRepository::formatText)
-                .orElse("주문번호 [" + orderId + "]에 해당하는 주문 정보를 찾을 수 없습니다. 고객에게 주문번호를 다시 확인해달라고 안내하세요.");
+                .map(o -> ToolResult.success(orderRepository.formatText(o)))
+                .orElseGet(() -> ToolResult.error(
+                        ToolErrorCategory.NOT_FOUND,
+                        false,
+                        "주문번호 [" + orderId + "]에 해당하는 주문 정보를 찾을 수 없습니다. "
+                                + "고객에게 주문번호를 다시 확인해달라고 followUpQuestion으로 요청하세요."));
     }
 }

--- a/src/main/java/com/aicsassistant/analysis/agent/tool/SearchManualTool.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/tool/SearchManualTool.java
@@ -1,6 +1,8 @@
 package com.aicsassistant.analysis.agent.tool;
 
 import com.aicsassistant.analysis.agent.AgentTool;
+import com.aicsassistant.analysis.agent.ToolErrorCategory;
+import com.aicsassistant.analysis.agent.ToolResult;
 import com.aicsassistant.analysis.application.ManualRetrievalService;
 import com.aicsassistant.analysis.dto.RetrievedManualChunkDto;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,10 +36,13 @@ public class SearchManualTool implements AgentTool {
     }
 
     @Override
-    public String execute(JsonNode input) {
+    public ToolResult execute(JsonNode input) {
         String query = input.path("query").asText("").strip();
         if (query.isBlank()) {
-            return "Error: 'query' field is required.";
+            return ToolResult.error(
+                    ToolErrorCategory.VALIDATION,
+                    false,
+                    "'query' field is required.");
         }
 
         List<RetrievedManualChunkDto> chunks = manualRetrievalService.retrieve(query);
@@ -45,13 +50,14 @@ public class SearchManualTool implements AgentTool {
         collectedChunks.addAll(chunks);
 
         if (chunks.isEmpty()) {
-            return "No relevant policy documents found for this query.";
+            return ToolResult.success("No relevant policy documents found for this query.");
         }
 
-        return chunks.stream()
+        String formatted = chunks.stream()
                 .map(c -> "[%s / %s]\n%s".formatted(
                         c.manualDocumentTitle(), c.manualCategory(), c.content()))
                 .collect(Collectors.joining("\n\n---\n\n"));
+        return ToolResult.success(formatted);
     }
 
     /** Returns all chunks retrieved across every call during this agent run. */

--- a/src/main/java/com/aicsassistant/analysis/application/PromptFactory.java
+++ b/src/main/java/com/aicsassistant/analysis/application/PromptFactory.java
@@ -39,6 +39,17 @@ public class PromptFactory {
                 ## Available Tools
                 %s
 
+                ## Tool Observation Schema
+                Every tool call returns a JSON observation with this shape:
+                - Success: {"ok": true, "data": "<result text>"}
+                - Failure: {"ok": false, "errorCategory": "<TRANSIENT|VALIDATION|PERMISSION|NOT_FOUND>", "isRetryable": <bool>, "errorMessage": "<reason>"}
+
+                React to failures by errorCategory:
+                - TRANSIENT (isRetryable=true): retry the SAME call once. If it fails again, summarize and set needsHumanReview: true.
+                - VALIDATION: do NOT retry as-is. Either fix actionInput and retry, or use followUpQuestion to ask the customer for the missing field.
+                - PERMISSION: do NOT retry. Stop tool calls and produce finalAnswer with needsEscalation: true.
+                - NOT_FOUND: do NOT retry the same input. Use followUpQuestion to confirm the identifier with the customer, or set needsHumanReview: true if already confirmed.
+
                 ## Response Format
                 Always respond with raw JSON only — no markdown, no code blocks.
 

--- a/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTest.java
+++ b/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTest.java
@@ -105,6 +105,27 @@ class InquiryAgentServiceTest {
     }
 
     @Test
+    void wrapsToolExceptionAsTransientObservation() {
+        givenLlmResponds(
+                toolCall("search_manual", "{\"query\":\"환불\"}"),
+                finalAnswer("일시적 오류로 답변이 어렵습니다.", "GENERAL", "LOW", true)
+        );
+        when(manualRetrievalService.retrieve(any()))
+                .thenThrow(new RuntimeException("DB connection lost"));
+
+        AgentResult result = agentService.run(inquiry("환불 문의"), List.of());
+
+        AgentResult.FinalAnswer answer = (AgentResult.FinalAnswer) result;
+        assertThat(answer.steps()).hasSize(1);
+        AgentStep step = answer.steps().get(0);
+        assertThat(step.observation())
+                .contains("\"ok\":false")
+                .contains("\"errorCategory\":\"TRANSIENT\"")
+                .contains("\"isRetryable\":true")
+                .contains("DB connection lost");
+    }
+
+    @Test
     void accumulatesTotalTokensAcrossSteps() {
         givenLlmResponds(
                 toolCall("search_manual", "{\"query\":\"배송\"}"),

--- a/src/test/java/com/aicsassistant/analysis/agent/tool/CheckOrderStatusToolTest.java
+++ b/src/test/java/com/aicsassistant/analysis/agent/tool/CheckOrderStatusToolTest.java
@@ -1,0 +1,48 @@
+package com.aicsassistant.analysis.agent.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aicsassistant.analysis.agent.ToolErrorCategory;
+import com.aicsassistant.analysis.agent.ToolResult;
+import com.aicsassistant.order.InMemoryOrderRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class CheckOrderStatusToolTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CheckOrderStatusTool tool = new CheckOrderStatusTool(new InMemoryOrderRepository());
+
+    @Test
+    void returnsSuccessForKnownOrderId() {
+        ToolResult result = tool.execute(input("ORD-20260410-001"));
+
+        assertThat(result.ok()).isTrue();
+        assertThat(result.data()).contains("주문번호: ORD-20260410-001");
+        assertThat(result.errorCategory()).isNull();
+    }
+
+    @Test
+    void returnsValidationErrorWhenOrderIdMissing() {
+        ToolResult result = tool.execute(input(""));
+
+        assertThat(result.ok()).isFalse();
+        assertThat(result.errorCategory()).isEqualTo(ToolErrorCategory.VALIDATION);
+        assertThat(result.isRetryable()).isFalse();
+        assertThat(result.errorMessage()).contains("orderId");
+    }
+
+    @Test
+    void returnsNotFoundForUnknownOrderId() {
+        ToolResult result = tool.execute(input("ORD-DOES-NOT-EXIST"));
+
+        assertThat(result.ok()).isFalse();
+        assertThat(result.errorCategory()).isEqualTo(ToolErrorCategory.NOT_FOUND);
+        assertThat(result.isRetryable()).isFalse();
+    }
+
+    private ObjectNode input(String orderId) {
+        return objectMapper.createObjectNode().put("orderId", orderId);
+    }
+}

--- a/src/test/java/com/aicsassistant/analysis/agent/tool/SearchManualToolTest.java
+++ b/src/test/java/com/aicsassistant/analysis/agent/tool/SearchManualToolTest.java
@@ -1,0 +1,65 @@
+package com.aicsassistant.analysis.agent.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.aicsassistant.analysis.agent.ToolErrorCategory;
+import com.aicsassistant.analysis.agent.ToolResult;
+import com.aicsassistant.analysis.application.ManualRetrievalService;
+import com.aicsassistant.analysis.dto.RetrievedManualChunkDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SearchManualToolTest {
+
+    @Mock ManualRetrievalService manualRetrievalService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void returnsValidationErrorWhenQueryMissing() {
+        SearchManualTool tool = new SearchManualTool(manualRetrievalService);
+
+        ToolResult result = tool.execute(input(""));
+
+        assertThat(result.ok()).isFalse();
+        assertThat(result.errorCategory()).isEqualTo(ToolErrorCategory.VALIDATION);
+        assertThat(result.isRetryable()).isFalse();
+        assertThat(result.errorMessage()).contains("query");
+    }
+
+    @Test
+    void returnsSuccessWhenChunksFound() {
+        SearchManualTool tool = new SearchManualTool(manualRetrievalService);
+        when(manualRetrievalService.retrieve(any())).thenReturn(List.of(
+                new RetrievedManualChunkDto(1L, 10L, "환불 정책", "REFUND", 0, 1, 50, "환불 가능 기간은 7일입니다.")
+        ));
+
+        ToolResult result = tool.execute(input("환불 정책"));
+
+        assertThat(result.ok()).isTrue();
+        assertThat(result.data()).contains("환불 정책").contains("환불 가능 기간은 7일입니다.");
+    }
+
+    @Test
+    void returnsSuccessWithEmptyMarkerWhenNoChunks() {
+        SearchManualTool tool = new SearchManualTool(manualRetrievalService);
+        when(manualRetrievalService.retrieve(any())).thenReturn(List.of());
+
+        ToolResult result = tool.execute(input("존재하지 않는 정책"));
+
+        assertThat(result.ok()).isTrue();
+        assertThat(result.data()).contains("No relevant policy documents");
+    }
+
+    private ObjectNode input(String query) {
+        return objectMapper.createObjectNode().put("query", query);
+    }
+}


### PR DESCRIPTION
Closes #1

## Summary
- `AgentTool.execute()` 반환 타입을 단순 `String` → 구조화된 `ToolResult`로 변경
- `ToolErrorCategory`(TRANSIENT/VALIDATION/PERMISSION/NOT_FOUND) + `isRetryable` 필드로 실패 의미를 LLM에 명확히 전달
- 시스템 프롬프트에 에러 카테고리별 권장 대응(재시도/입력수정/에스컬레이션/followUp) 추가

## 동기
공식 가이드 *"Build a Multi-Tool Agent with Escalation Logic"* 연습 1·3단계: 구조화된 에러 응답이 있어야 에이전트가 재시도/입력수정/에스컬레이션 중 올바른 다음 행동을 선택할 수 있음. 기존 코드는 `"Tool execution error: " + e.getMessage()` 같은 평문이라 LLM이 의미를 추론할 수밖에 없었음.

## 변경 파일
- `analysis/agent/ToolErrorCategory.java` *(신규)*
- `analysis/agent/ToolResult.java` *(신규)*
- `analysis/agent/AgentTool.java` — 시그니처 변경
- `analysis/agent/InquiryAgentService.java` — 예외를 TRANSIENT로 래핑, observation을 JSON 직렬화
- `analysis/agent/tool/SearchManualTool.java`, `CheckOrderStatusTool.java` — `ToolResult` 반환
- `analysis/application/PromptFactory.java` — Tool Observation Schema 섹션 추가
- 테스트: `SearchManualToolTest`, `CheckOrderStatusToolTest` 신규 + `InquiryAgentServiceTest`에 TRANSIENT 케이스 추가

## Observation 형식
- 성공: `{"ok":true,"data":"..."}`
- 실패: `{"ok":false,"errorCategory":"VALIDATION","isRetryable":false,"errorMessage":"..."}`

## Test plan
- [x] `./gradlew compileJava compileTestJava` — 통과
- [x] `./gradlew test --tests "com.aicsassistant.analysis.agent.*"` — 13/13 통과 (Agent 7, SearchManualTool 3, CheckOrderStatusTool 3)
- [x] `CounselorViewControllerTest` 실패는 main에서도 동일하게 발생하는 사전 존재 이슈로, 본 PR과 무관함을 확인
- [ ] (수동) Railway 배포 후 실제 LLM이 새 observation 스키마를 적절히 해석하는지 샘플 문의로 확인

## 다음 단계 (이 PR 외)
가이드 4·5단계는 후속 PR로:
1. 도구 호출 인터셉터 훅 (금액 임계, 권한 가드)
2. 다중 관심사 메시지 통합 테스트 시나리오 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)