### PR TITLE
다중 관심사 메시지 분해/통합 처리 (가이드 5단계)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ sequenceDiagram
     C->>A: 문의 내용 + 주문 정보 선주입
     A->>L: System Prompt + 문의 내용
 
+    Note over L: 다중 관심사면 첫 thought에서<br/>각 관심사를 열거 (분해)
+
     loop ReAct 루프 (최대 8스텝)
         L-->>A: Thought: "환불 정책을 확인해야 한다"
         L-->>A: Action: search_manual("환불 기간")
@@ -273,6 +275,9 @@ public interface AgentTool<I> {
 
 세 도구의 `usageBoundary`는 서로를 명시적으로 가리키며 (`search_faq` NOT_FOUND → `search_manual` 폴백, 등), `PromptFactory.Guidelines`에 한 줄짜리 도구 선택 규칙을 함께 노출합니다. 모델이 description의 자기설명만으로 단순 FAQ는 `search_faq`로 즉답하고, 매칭 실패 시 자동으로 `search_manual`로 폴백하는 흐름을 통합 테스트로 보호합니다.
 
+### 13. 다중 관심사 메시지 분해/통합 처리
+한 메시지에 여러 요청이 섞여 있을 때(예: *"ORD-XXX 배송 언제 와요? 그리고 반품 정책 알려주세요"*) Agent가 각 관심사를 첫 `thought`에서 열거하고, 필요한 도구를 모두 호출한 뒤, 관심사별 헤더(`1)`, `2)`)가 붙은 **하나의 통합된 finalAnswer**를 생성합니다. 자동 처리 가능한 부분과 상담사 액션이 필요한 부분이 섞여 있으면 답할 수 있는 부분은 즉시 답하고 나머지는 `needsHumanReview: true`로 라우팅합니다. 가드(예산 초과, 정책 가드)가 중간에 발동해 일부만 처리된 경우에도 누락 없이 "처리 완료 / 상담사 인계" 구분을 명시합니다.
+
 ---
 
 ## 배포
@@ -351,6 +356,11 @@ export APP_SLACK_WEBHOOK_URL=https://hooks.slack.com/...   # 선택
 **4. 메뉴얼 추가 전후 비교**
 - `/ui/manuals` → 직접 입력으로 새 정책 등록
 - 동일한 문의를 등록 전/후로 비교해 RAG 반영 여부 확인
+
+**5. 다중 관심사 메시지**
+- 유형: 배송 문의 / 주문: `ORD-20260410-001` 선택
+- 내용: "배송 언제 와요? 그리고 반품 가능 기간도 알려주세요"
+- → Agent가 `check_order_status` + `search_manual` 두 도구를 모두 호출 → `1) 배송: ... 2) 반품: ...` 형태로 통합 답변
 
 ---
 

--- a/src/main/java/com/aicsassistant/analysis/application/PromptFactory.java
+++ b/src/main/java/com/aicsassistant/analysis/application/PromptFactory.java
@@ -53,6 +53,14 @@ public class PromptFactory {
                 ## Policy Guards (injected at runtime)
                 Some tool responses may contain a "[정책 가드: ...]" note appended to the success data. Treat that note as a hard rule: even if your own reasoning would otherwise auto-process the request, follow the note's instruction (e.g. set needsHumanReview/needsEscalation true). Do not summarize the guard text to the customer.
 
+                ## Multi-Concern Decomposition
+                Customer messages may contain MULTIPLE independent requests in one turn (e.g. "ORD-XXX 배송 언제 와요? 그리고 반품 정책 알려주세요"). Handle them as follows:
+                - In your FIRST `thought`, enumerate every distinct concern you detect (e.g. "[1] 배송 조회 ORD-XXX, [2] 반품 정책").
+                - Call the necessary tool for each concern. You may interleave tool calls, but make sure every concern gets the information it needs before producing finalAnswer.
+                - Produce ONE finalAnswer that addresses every concern. Use a short header per concern (e.g. "1) 배송: ...", "2) 반품 정책: ...") so the customer can match each answer to their question.
+                - If some concerns are auto-answerable but others require human action (refund, cancellation, exchange, account fix): answer the auto-answerable parts in finalAnswer, then explicitly note the human-action parts will be handled by 상담사. Set needsHumanReview: true.
+                - If a guard fires mid-run (PERMISSION error, [정책 가드] note) and you cannot finish all concerns: produce finalAnswer that summarizes what you DID resolve and what is pending, then set needsHumanReview: true. Never silently drop a concern.
+
                 ## Response Format
                 Always respond with raw JSON only — no markdown, no code blocks.
 

--- a/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTest.java
+++ b/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTest.java
@@ -258,6 +258,89 @@ class InquiryAgentServiceTest {
     }
 
     @Test
+    void multiConcernAllAutoAnswerable_callsBothToolsAndProducesUnifiedAnswer() {
+        // 케이스 1: "ORD 배송 조회 + 반품 정책" — 두 도구 모두 호출 후 통합 답변
+        givenLlmResponds(
+                toolCall("check_order_status", "{\"orderId\":\"ORD-20260410-001\"}"),
+                toolCall("search_manual", "{\"query\":\"반품 정책\"}"),
+                finalAnswer(
+                        "1) 배송: 4월 13일 도착 예정입니다. 2) 반품 정책: 수령 후 7일 이내 가능합니다.",
+                        "DELIVERY", "MEDIUM", false)
+        );
+        when(manualRetrievalService.retrieve(any())).thenReturn(List.of());
+
+        AgentResult result = agentService.run(
+                inquiry("ORD-20260410-001 배송 언제 와요? 그리고 반품 정책 알려주세요"), List.of());
+
+        AgentResult.FinalAnswer answer = (AgentResult.FinalAnswer) result;
+        assertThat(answer.steps()).hasSize(2);
+        assertThat(answer.steps().get(0).action()).isEqualTo("check_order_status");
+        assertThat(answer.steps().get(1).action()).isEqualTo("search_manual");
+        assertThat(answer.answer()).contains("배송").contains("반품 정책");
+        assertThat(answer.needsHumanReview()).isFalse();
+    }
+
+    @Test
+    void multiConcernPartialEscalation_answersPolicyAndFlagsRefundForHuman() {
+        // 케이스 2: "환불 처리 + 반품 정책" — 정책은 답변, 환불 액션은 needsHumanReview true
+        givenLlmResponds(
+                toolCall("search_manual", "{\"query\":\"반품 정책\"}"),
+                finalAnswer(
+                        "1) 반품 정책: 수령 후 7일 이내 가능합니다. 2) 환불 처리: 담당자가 확인 후 처리해 드리겠습니다.",
+                        "REFUND", "MEDIUM", true)
+        );
+        when(manualRetrievalService.retrieve(any())).thenReturn(List.of());
+
+        AgentResult result = agentService.run(
+                inquiry("환불 처리해주세요. 그리고 반품 정책도 알려주세요"), List.of());
+
+        AgentResult.FinalAnswer answer = (AgentResult.FinalAnswer) result;
+        assertThat(answer.needsHumanReview()).isTrue();
+        assertThat(answer.answer())
+                .contains("반품 정책")
+                .contains("담당자가 확인");
+    }
+
+    @Test
+    void multiConcernBudgetGuard_summarizesPartialAnswerAndEscalates() {
+        // 케이스 3: 예산 가드(6회 한도) 발동 후 부분 답변 + needsHumanReview
+        // 인터셉터가 즉시 차단하면 도구는 실행되지 않고 PERMISSION 에러가 observation에 들어감.
+        InquiryAgentService budgetExhaustedAgent = new InquiryAgentService(
+                llmClient, manualRetrievalService, promptFactory, new ObjectMapper(),
+                new InMemoryOrderRepository(),
+                new InMemoryFaqRepository(),
+                List.of(new com.aicsassistant.analysis.agent.ToolCallInterceptor() {
+                    @Override
+                    public java.util.Optional<com.aicsassistant.analysis.agent.ToolResult> beforeExecute(
+                            String toolName, com.fasterxml.jackson.databind.JsonNode input,
+                            com.aicsassistant.analysis.agent.ToolCallContext ctx) {
+                        return java.util.Optional.of(com.aicsassistant.analysis.agent.ToolResult.error(
+                                com.aicsassistant.analysis.agent.ToolErrorCategory.PERMISSION,
+                                false,
+                                "Tool call budget exhausted"));
+                    }
+                }));
+        givenLlmResponds(
+                toolCall("search_manual", "{\"query\":\"반품 정책\"}"),
+                finalAnswer(
+                        "1) 반품 정책: 일부 정보만 확인했습니다. 2) 그 외 요청은 담당자가 확인 후 처리해 드리겠습니다.",
+                        "RETURN", "MEDIUM", true)
+        );
+
+        AgentResult result = budgetExhaustedAgent.run(
+                inquiry("반품 정책 알려주고, ORD-A 환불, ORD-B 교환, 적립금 환급도 부탁해요"),
+                List.of());
+
+        AgentResult.FinalAnswer answer = (AgentResult.FinalAnswer) result;
+        assertThat(answer.needsHumanReview()).isTrue();
+        AgentStep guardedStep = answer.steps().get(0);
+        assertThat(guardedStep.observation())
+                .contains("\"errorCategory\":\"PERMISSION\"")
+                .contains("budget exhausted");
+        assertThat(answer.answer()).contains("담당자");
+    }
+
+    @Test
     void accumulatesTotalTokensAcrossSteps() {
         givenLlmResponds(
                 toolCall("search_manual", "{\"query\":\"배송\"}"),


### PR DESCRIPTION
Closes #5

## Summary
- 시스템 프롬프트에 **Multi-Concern Decomposition** 섹션 추가 — 다중 관심사 분해→각 도구 호출→통합 답변 명시
- `InquiryAgentServiceTest`에 다중 관심사 통합 시나리오 3개 추가 (회귀 보호)
- README: ReAct 시퀀스 다이어그램에 분해 노트, 설계 결정 #11, 데모 시나리오 5번 추가

## 동기
공식 가이드 *"Build a Multi-Tool Agent with Escalation Logic"* 5단계 마무리. 기존 프롬프트엔 분해 지시가 없어 LLM이 한 가지에만 답할 위험이 있었고, 통합 테스트도 단일 관심사만 다루었습니다.

## 변경 파일
- `analysis/application/PromptFactory.java` — Multi-Concern Decomposition 섹션
- `src/test/.../analysis/agent/InquiryAgentServiceTest.java` — 시나리오 3개 추가
- `README.md` — 시퀀스 다이어그램 노트, 설계 결정 #11, 데모 시나리오 5번

## 추가된 시나리오
| 케이스 | 입력 | 기대 동작 |
|---|---|---|
| 모두 자동 | "ORD 배송 + 반품 정책" | `check_order_status` + `search_manual` 둘 다 호출 → `1) 배송… 2) 반품…` 통합 답변, needsHumanReview=false |
| 부분 에스컬레이션 | "환불 처리 + 반품 정책" | 정책 답변 포함 + 환불 부분은 needsHumanReview=true |
| 가드 발동 | 4가지 요청 + 인터셉터가 즉시 PERMISSION 차단 | 부분 답변(반품 정책) + 나머지는 상담사 인계 + needsHumanReview=true |

## Test plan
- [x] `./gradlew test --tests "com.aicsassistant.analysis.agent.InquiryAgentServiceTest"` — 12/12 통과 (기존 9 + 신규 3)
- [ ] (수동) Railway 배포 후 데모 시나리오 5번으로 실제 LLM이 분해 후 두 도구 모두 호출하는지 확인

## 가이드 5개 항목 최종 매핑
1. ✅ 다중 도구 정의 (search_manual, check_order_status — 의도적 2개 유지)
2. ✅ 에이전트 루프 / stop_reason 분기 (`AgentResult` sealed)
3. ✅ 구조화된 에러 응답 (`ToolResult`, PR #2)
4. ✅ 프로그래밍적 훅 (`ToolCallInterceptor`, PR #4)
5. ✅ 다중 관심사 메시지 처리 (이 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)