### PR TITLE
유사 기능 도구 추가 (search_faq) — usageBoundary 효과 검증 + 가이드 1단계 마무리

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ flowchart TB
     subgraph Agent["ReAct Agent"]
         AgentLoop["InquiryAgentService\nMAX 8 스텝 루프\nJsonNode → typed Input 역직렬화"]
         Interceptors["ToolCallInterceptor 체인\n(예산·고액 주문 가드)"]
-        SearchTool["SearchManualTool\nAgentTool&lt;Input&gt;"]
-        OrderTool["CheckOrderStatusTool\nAgentTool&lt;Input&gt;"]
+        FaqTool["SearchFaqTool\n큐레이션 단답"]
+        SearchTool["SearchManualTool\n정책 원문 RAG"]
+        OrderTool["CheckOrderStatusTool\n주문 데이터"]
     end
 
     subgraph RAG["RAG 파이프라인"]
@@ -74,7 +75,8 @@ flowchart TB
     InquiryService -->|InquiryCreatedEvent| EventListener
     EventListener --> AnalysisService
     AnalysisService --> AgentLoop
-    AgentLoop --> Interceptors --> SearchTool & OrderTool
+    AgentLoop --> Interceptors --> FaqTool & SearchTool & OrderTool
+    FaqTool --> InMemoryFaq["InMemoryFaqRepository\n(데모용 Mock)"]
     SearchTool --> VectorRepo
     OrderTool --> InMemoryOrder["InMemoryOrderRepository\n(데모용 Mock)"]
     VectorRepo -->|코사인 유사도| T4
@@ -258,7 +260,18 @@ public interface AgentTool<I> {
 }
 ```
 
-각 도구는 자기 입력을 nested record로 선언하고(`SearchManualTool.Input`, `CheckOrderStatusTool.Input`), `InquiryAgentService`가 `ObjectMapper.treeToValue`로 JsonNode → record를 자동 변환합니다. 변환 실패는 `ToolResult.error(VALIDATION, ...)`로 LLM에 반환되어 입력 수정/추가 질문 흐름이 자동 트리거됩니다. `PromptFactory`는 도구별 7개 표면을 통일된 블록으로 시스템 프롬프트에 노출해 모델이 첫 호출 전에 모든 정보를 갖게 합니다. 특히 `usageBoundary`는 **유사 기능 도구가 늘어났을 때 모델의 도구 선택 정확도를 좌우하는 핵심 신호**입니다.
+각 도구는 자기 입력을 nested record로 선언하고(`SearchManualTool.Input`, `CheckOrderStatusTool.Input`, `SearchFaqTool.Input`), `InquiryAgentService`가 `ObjectMapper.treeToValue`로 JsonNode → record를 자동 변환합니다. 변환 실패는 `ToolResult.error(VALIDATION, ...)`로 LLM에 반환되어 입력 수정/추가 질문 흐름이 자동 트리거됩니다. `PromptFactory`는 도구별 7개 표면을 통일된 블록으로 시스템 프롬프트에 노출해 모델이 첫 호출 전에 모든 정보를 갖게 합니다. 특히 `usageBoundary`는 **유사 기능 도구가 늘어났을 때 모델의 도구 선택 정확도를 좌우하는 핵심 신호**입니다.
+
+### 12. 유사 기능 도구 차별화 (search_faq vs search_manual)
+가이드 1단계의 "유사 기능 도구를 두어 description 차별화 압력을 만든다" 연습. 두 도구가 모두 정책 정보 텍스트를 반환하지만 의도가 다릅니다.
+
+| 도구 | 무엇을 반환 | 언제 호출 | 비용/응답 길이 |
+|---|---|---|---|
+| `search_faq` | 큐레이션된 짧은 Q&A 1개 | 자주 묻는 단순 질문 (환불 며칠 / 회원 탈퇴 등) | 저비용·즉답 |
+| `search_manual` | 정책 원문 청크 N개 (RAG) | 정확한 조항/예외/세부 절차 | 고비용·길이 김 |
+| `check_order_status` | 특정 주문 데이터 | 고객이 주문 ID 명시 | mock 조회 |
+
+세 도구의 `usageBoundary`는 서로를 명시적으로 가리키며 (`search_faq` NOT_FOUND → `search_manual` 폴백, 등), `PromptFactory.Guidelines`에 한 줄짜리 도구 선택 규칙을 함께 노출합니다. 모델이 description의 자기설명만으로 단순 FAQ는 `search_faq`로 즉답하고, 매칭 실패 시 자동으로 `search_manual`로 폴백하는 흐름을 통합 테스트로 보호합니다.
 
 ---
 
@@ -354,7 +367,7 @@ src/main/java/com/aicsassistant/
 ├── analysis/               # AI 분석 도메인
 │   ├── agent/              # ReAct Agent 루프, AgentTool, ToolResult, ToolCallInterceptor
 │   │   ├── interceptor/    # ToolCallBudgetInterceptor, HighValueOrderInterceptor
-│   │   └── tool/           # SearchManualTool, CheckOrderStatusTool
+│   │   └── tool/           # SearchFaqTool, SearchManualTool, CheckOrderStatusTool
 │   ├── application/        # InquiryAnalysisService, AnalysisLogService
 │   ├── api/
 │   ├── domain/             # InquiryAnalysisLog
@@ -365,6 +378,7 @@ src/main/java/com/aicsassistant/
 │   ├── application/        # ManualService, ManualChunker
 │   ├── api/
 │   └── infra/              # ManualChunkJdbcRepository (pgvector)
+├── faq/                    # 자주 묻는 질문 (InMemoryFaqRepository — 데모 Mock)
 ├── order/                  # 주문 조회 (InMemoryOrderRepository — 데모 Mock)
 ├── user/                   # 더미 유저 스토어 (데모용)
 ├── ui/                     # Thymeleaf 뷰 컨트롤러

--- a/src/main/java/com/aicsassistant/analysis/agent/InquiryAgentService.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/InquiryAgentService.java
@@ -1,7 +1,9 @@
 package com.aicsassistant.analysis.agent;
 
 import com.aicsassistant.analysis.agent.tool.CheckOrderStatusTool;
+import com.aicsassistant.analysis.agent.tool.SearchFaqTool;
 import com.aicsassistant.analysis.agent.tool.SearchManualTool;
+import com.aicsassistant.faq.InMemoryFaqRepository;
 import com.aicsassistant.analysis.application.ManualRetrievalService;
 import com.aicsassistant.analysis.application.PromptFactory;
 import com.aicsassistant.analysis.dto.RetrievedManualChunkDto;
@@ -44,6 +46,7 @@ public class InquiryAgentService {
     private final PromptFactory promptFactory;
     private final ObjectMapper objectMapper;
     private final InMemoryOrderRepository orderRepository;
+    private final InMemoryFaqRepository faqRepository;
     private final List<ToolCallInterceptor> interceptors;
 
     /**
@@ -53,7 +56,8 @@ public class InquiryAgentService {
     public AgentResult run(Inquiry inquiry, List<InquiryMessage> conversationHistory) {
         CheckOrderStatusTool orderTool = new CheckOrderStatusTool(orderRepository);
         SearchManualTool searchTool = new SearchManualTool(manualRetrievalService);
-        List<AgentTool<?>> tools = List.of(searchTool, orderTool);
+        SearchFaqTool faqTool = new SearchFaqTool(faqRepository);
+        List<AgentTool<?>> tools = List.of(faqTool, searchTool, orderTool);
 
         List<ChatMessage> messages = new ArrayList<>();
         messages.add(ChatMessage.system(promptFactory.buildAgentSystemPrompt(tools)));

--- a/src/main/java/com/aicsassistant/analysis/agent/tool/CheckOrderStatusTool.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/tool/CheckOrderStatusTool.java
@@ -38,8 +38,9 @@ public class CheckOrderStatusTool implements AgentTool<CheckOrderStatusTool.Inpu
 
     @Override
     public String usageBoundary() {
-        return "Do NOT use for: general policy questions (use search_manual), questions about orders the customer has not identified, "
-                + "or to perform actions like cancellation/refund (this tool is read-only — for actions, set needsHumanReview: true).";
+        return "Do NOT use for: (1) general policy questions (use search_faq for short FAQs, search_manual for detailed policy), "
+                + "(2) questions about orders the customer has not identified by ID, "
+                + "(3) performing actions like cancellation/refund (this tool is read-only — for actions, set needsHumanReview: true).";
     }
 
     @Override

--- a/src/main/java/com/aicsassistant/analysis/agent/tool/SearchFaqTool.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/tool/SearchFaqTool.java
@@ -1,0 +1,92 @@
+package com.aicsassistant.analysis.agent.tool;
+
+import com.aicsassistant.analysis.agent.AgentTool;
+import com.aicsassistant.analysis.agent.ToolErrorCategory;
+import com.aicsassistant.analysis.agent.ToolResult;
+import com.aicsassistant.faq.InMemoryFaqRepository;
+import java.util.Optional;
+
+/**
+ * 큐레이션된 자주 묻는 질문(FAQ) 단답 검색 도구.
+ *
+ * <p>{@link SearchManualTool}과 의도적으로 기능이 겹친다. 모델이 도구 설명을 보고
+ * "긴 정책 원문이 필요한가? 짧은 즉답이 충분한가?"를 구분하는지 검증하기 위함.
+ */
+public class SearchFaqTool implements AgentTool<SearchFaqTool.Input> {
+
+    /** 도구 입력 — 한 문장의 자연어 질문. */
+    public record Input(String question) {}
+
+    private final InMemoryFaqRepository faqRepository;
+
+    public SearchFaqTool(InMemoryFaqRepository faqRepository) {
+        this.faqRepository = faqRepository;
+    }
+
+    @Override
+    public String name() {
+        return "search_faq";
+    }
+
+    @Override
+    public String description() {
+        return "Returns a single curated short answer to a frequently-asked customer question.";
+    }
+
+    @Override
+    public String whenToUse() {
+        return "Call FIRST for short, common, well-known questions where a one-paragraph answer is enough "
+                + "(e.g. '환불 며칠 걸려요?', '배송 조회는 어디?', '회원 탈퇴는?', '쿠폰 확인'). "
+                + "Cheaper and more direct than search_manual for these cases.";
+    }
+
+    @Override
+    public String usageBoundary() {
+        return "Do NOT use for: (1) questions requiring exact policy clauses or legal-style detail "
+                + "(use search_manual instead — its chunks are longer and authoritative), "
+                + "(2) order-specific data (use check_order_status), "
+                + "(3) novel/edge-case questions unlikely to be in a FAQ list. "
+                + "If this tool returns NOT_FOUND, fall back to search_manual.";
+    }
+
+    @Override
+    public Class<Input> inputType() {
+        return Input.class;
+    }
+
+    @Override
+    public String inputSchema() {
+        return "{\"question\": \"string (required) — single Korean question, ideally short (e.g. '환불은 며칠 걸리나요?')\"}";
+    }
+
+    @Override
+    public String successOutputHint() {
+        return "A short single-paragraph answer text (not a chunk list). Suitable for direct customer reply with light formatting.";
+    }
+
+    @Override
+    public String failureBehavior() {
+        return "VALIDATION (empty question): rephrase the customer's request as a short question and retry. "
+                + "NOT_FOUND (no matching FAQ): do NOT retry the same question — call search_manual instead for a more detailed answer.";
+    }
+
+    @Override
+    public ToolResult execute(Input input) {
+        String question = input.question() == null ? "" : input.question().strip();
+        if (question.isBlank()) {
+            return ToolResult.error(
+                    ToolErrorCategory.VALIDATION,
+                    false,
+                    "'question' field is required.");
+        }
+        Optional<InMemoryFaqRepository.FaqEntry> match = faqRepository.findBest(question);
+        if (match.isEmpty()) {
+            return ToolResult.error(
+                    ToolErrorCategory.NOT_FOUND,
+                    false,
+                    "FAQ에서 일치하는 항목을 찾지 못했습니다. 더 자세한 정책 정보를 위해 search_manual을 호출하세요.");
+        }
+        InMemoryFaqRepository.FaqEntry entry = match.get();
+        return ToolResult.success("Q: " + entry.question() + "\nA: " + entry.answer());
+    }
+}

--- a/src/main/java/com/aicsassistant/analysis/agent/tool/SearchManualTool.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/tool/SearchManualTool.java
@@ -44,8 +44,9 @@ public class SearchManualTool implements AgentTool<SearchManualTool.Input> {
 
     @Override
     public String usageBoundary() {
-        return "Do NOT use for: order-specific status/tracking/amount lookups (use check_order_status), "
-                + "or for customer personal info. This tool only returns generic policy text — it has no access to a specific customer's orders.";
+        return "Do NOT use for: (1) short well-known questions where a one-paragraph FAQ answer is enough (use search_faq first — cheaper and more direct), "
+                + "(2) order-specific status/tracking/amount lookups (use check_order_status), "
+                + "(3) customer personal info. This tool returns long authoritative policy chunks — overkill for simple FAQs.";
     }
 
     @Override

--- a/src/main/java/com/aicsassistant/analysis/application/PromptFactory.java
+++ b/src/main/java/com/aicsassistant/analysis/application/PromptFactory.java
@@ -97,7 +97,8 @@ public class PromptFactory {
                 fraudRiskFlag = true if the pattern suggests refund/return abuse or account fraud.
 
                 ## Guidelines
-                - Always call search_manual before answering any policy question
+                - Tool selection: short well-known question → search_faq · detailed/exact policy → search_manual · order-specific data → check_order_status
+                - For policy questions, prefer search_faq first; if it returns NOT_FOUND, fall back to search_manual
                 - Call check_order_status if the customer mentions an order ID
                 - If the customer's message lacks critical information (e.g. order ID for a delivery inquiry), use followUpQuestion to ask — do not guess
                 - You may ask follow-up questions up to 3 times total across the entire conversation. Count the number of followUpQuestion turns already in the conversation history and stop asking once 3 have been made.

--- a/src/main/java/com/aicsassistant/faq/InMemoryFaqRepository.java
+++ b/src/main/java/com/aicsassistant/faq/InMemoryFaqRepository.java
@@ -1,0 +1,84 @@
+package com.aicsassistant.faq;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 데모용 인메모리 FAQ 저장소.
+ *
+ * <p>실제 서비스에서는 큐레이션된 Q&A를 별도 테이블/검색 인덱스로 관리합니다.
+ * 여기서는 키워드 포함 매칭으로 단순 검색을 구현합니다.
+ *
+ * <p>설계 의도: {@code SearchManualTool}(정책 원문 RAG)과 의도적으로 기능이 겹치도록 둠.
+ * 모델이 도구 설명({@code usageBoundary})만 보고 두 도구를 구분할 수 있는지 검증하기 위한 데모.
+ */
+@Repository
+public class InMemoryFaqRepository {
+
+    public record FaqEntry(String question, String answer, List<String> keywords) {}
+
+    private static final List<FaqEntry> ENTRIES = List.of(
+            new FaqEntry(
+                    "환불은 며칠 걸리나요?",
+                    "환불 요청 승인 후 영업일 기준 2~3일 내에 결제 수단으로 환불이 완료됩니다. 카드 결제는 카드사 정책에 따라 추가 1~2일이 더 걸릴 수 있습니다.",
+                    List.of("환불", "환불기간", "환불일정", "며칠")),
+            new FaqEntry(
+                    "배송 조회는 어디서 하나요?",
+                    "마이페이지 > 주문 내역에서 운송장 번호를 확인하거나, 배송사 홈페이지에서 직접 조회 가능합니다.",
+                    List.of("배송조회", "배송", "운송장", "조회")),
+            new FaqEntry(
+                    "회원 탈퇴는 어떻게 하나요?",
+                    "마이페이지 > 설정 > 회원 탈퇴 메뉴에서 직접 탈퇴할 수 있습니다. 탈퇴 후 30일간 동일 이메일로 재가입이 제한됩니다.",
+                    List.of("탈퇴", "회원탈퇴", "계정삭제")),
+            new FaqEntry(
+                    "비밀번호 재설정은 어떻게 하나요?",
+                    "로그인 화면의 '비밀번호 찾기' → 가입 이메일 입력 → 메일로 받은 링크에서 새 비밀번호 설정.",
+                    List.of("비밀번호", "패스워드", "재설정", "찾기")),
+            new FaqEntry(
+                    "쿠폰은 어디서 확인하나요?",
+                    "마이페이지 > 쿠폰함에서 보유 중인 쿠폰과 만료일을 확인할 수 있습니다.",
+                    List.of("쿠폰", "할인쿠폰", "쿠폰함")),
+            new FaqEntry(
+                    "적립금은 어떻게 사용하나요?",
+                    "결제 화면에서 사용할 적립금을 입력하면 자동 차감됩니다. 최소 사용 금액은 1,000원이며 5,000원 단위로 사용 가능합니다.",
+                    List.of("적립금", "포인트", "마일리지")),
+            new FaqEntry(
+                    "교환은 가능한가요?",
+                    "수령일로부터 7일 이내, 상품 미사용 상태에서 교환 가능합니다. 단순 변심은 왕복 배송비가 부과됩니다.",
+                    List.of("교환", "사이즈교환", "색상교환")),
+            new FaqEntry(
+                    "주문 취소는 어떻게 하나요?",
+                    "출고 전이라면 마이페이지 > 주문 내역 > 취소 버튼으로 즉시 취소 가능합니다. 출고 후에는 반품 절차로 진행됩니다.",
+                    List.of("취소", "주문취소")),
+            new FaqEntry(
+                    "현금영수증 발급은?",
+                    "결제 시 현금영수증 신청을 체크하면 자동 발급됩니다. 사후 발급은 마이페이지 > 영수증 관리에서 가능합니다.",
+                    List.of("현금영수증", "영수증", "세금계산서")),
+            new FaqEntry(
+                    "고객센터 운영시간은?",
+                    "평일 오전 9시 ~ 오후 6시, 주말·공휴일 휴무. 채팅 상담은 24시간 가능하며 야간 문의는 다음 영업일에 순차 답변됩니다.",
+                    List.of("운영시간", "고객센터", "상담시간"))
+    );
+
+    /** 키워드 또는 질문 포함 매칭으로 가장 적합한 FAQ를 반환한다. */
+    public Optional<FaqEntry> findBest(String query) {
+        String normalized = query.toLowerCase(Locale.ROOT).replace(" ", "");
+        if (normalized.isEmpty()) {
+            return Optional.empty();
+        }
+        return ENTRIES.stream()
+                .filter(e -> matches(e, normalized))
+                .findFirst();
+    }
+
+    private boolean matches(FaqEntry entry, String normalizedQuery) {
+        for (String kw : entry.keywords()) {
+            if (normalizedQuery.contains(kw.toLowerCase(Locale.ROOT).replace(" ", ""))) {
+                return true;
+            }
+        }
+        return entry.question().toLowerCase(Locale.ROOT).replace(" ", "").contains(normalizedQuery);
+    }
+}

--- a/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTest.java
+++ b/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTest.java
@@ -10,6 +10,7 @@ import com.aicsassistant.analysis.application.ManualRetrievalService;
 import com.aicsassistant.analysis.application.PromptFactory;
 import com.aicsassistant.analysis.infra.llm.LlmClient;
 import com.aicsassistant.analysis.infra.llm.LlmResponse;
+import com.aicsassistant.faq.InMemoryFaqRepository;
 import com.aicsassistant.inquiry.domain.Inquiry;
 import com.aicsassistant.order.InMemoryOrderRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,6 +39,7 @@ class InquiryAgentServiceTest {
                 promptFactory,
                 new ObjectMapper(),
                 new InMemoryOrderRepository(),
+                new InMemoryFaqRepository(),
                 List.of()
         );
     }
@@ -110,6 +112,7 @@ class InquiryAgentServiceTest {
         InquiryAgentService serviceWithBlocker = new InquiryAgentService(
                 llmClient, manualRetrievalService, promptFactory, new ObjectMapper(),
                 new InMemoryOrderRepository(),
+                new InMemoryFaqRepository(),
                 List.of(new com.aicsassistant.analysis.agent.ToolCallInterceptor() {
                     @Override
                     public java.util.Optional<com.aicsassistant.analysis.agent.ToolResult> beforeExecute(
@@ -139,6 +142,7 @@ class InquiryAgentServiceTest {
         InquiryAgentService serviceWithDecorator = new InquiryAgentService(
                 llmClient, manualRetrievalService, promptFactory, new ObjectMapper(),
                 new InMemoryOrderRepository(),
+                new InMemoryFaqRepository(),
                 List.of(new com.aicsassistant.analysis.agent.ToolCallInterceptor() {
                     @Override
                     public com.aicsassistant.analysis.agent.ToolResult afterExecute(
@@ -159,6 +163,43 @@ class InquiryAgentServiceTest {
 
         AgentStep step = ((AgentResult.FinalAnswer) result).steps().get(0);
         assertThat(step.observation()).contains("[GUARD]");
+    }
+
+    @Test
+    void faqMissThenFallsBackToManualSearch() {
+        // 가이드 시나리오: search_faq가 NOT_FOUND를 반환하면 LLM이 search_manual로 폴백해야 함
+        givenLlmResponds(
+                toolCall("search_faq", "{\"question\":\"우주선 발사 절차\"}"),
+                toolCall("search_manual", "{\"query\":\"우주선 발사\"}"),
+                finalAnswer("죄송합니다, 관련 정책을 찾지 못했습니다.", "GENERAL", "LOW", true)
+        );
+        when(manualRetrievalService.retrieve(any())).thenReturn(List.of());
+
+        AgentResult result = agentService.run(inquiry("우주선 발사 절차 알려주세요"), List.of());
+
+        AgentResult.FinalAnswer answer = (AgentResult.FinalAnswer) result;
+        assertThat(answer.steps()).hasSize(2);
+        assertThat(answer.steps().get(0).action()).isEqualTo("search_faq");
+        assertThat(answer.steps().get(0).observation())
+                .contains("\"errorCategory\":\"NOT_FOUND\"")
+                .contains("search_manual");
+        assertThat(answer.steps().get(1).action()).isEqualTo("search_manual");
+    }
+
+    @Test
+    void faqAnswersCommonQuestionWithoutManualFallback() {
+        // 단순 FAQ는 search_faq 한 번으로 처리, search_manual 호출 없이 finalAnswer
+        givenLlmResponds(
+                toolCall("search_faq", "{\"question\":\"환불 며칠 걸려요?\"}"),
+                finalAnswer("환불은 영업일 2~3일 내에 처리됩니다.", "REFUND", "LOW", false)
+        );
+
+        AgentResult result = agentService.run(inquiry("환불 며칠 걸려요?"), List.of());
+
+        AgentResult.FinalAnswer answer = (AgentResult.FinalAnswer) result;
+        assertThat(answer.steps()).hasSize(1);
+        assertThat(answer.steps().get(0).action()).isEqualTo("search_faq");
+        assertThat(answer.steps().get(0).observation()).contains("\"ok\":true");
     }
 
     @Test

--- a/src/test/java/com/aicsassistant/analysis/agent/tool/SearchFaqToolTest.java
+++ b/src/test/java/com/aicsassistant/analysis/agent/tool/SearchFaqToolTest.java
@@ -1,0 +1,72 @@
+package com.aicsassistant.analysis.agent.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aicsassistant.analysis.agent.ToolErrorCategory;
+import com.aicsassistant.analysis.agent.ToolResult;
+import com.aicsassistant.faq.InMemoryFaqRepository;
+import org.junit.jupiter.api.Test;
+
+class SearchFaqToolTest {
+
+    private final SearchFaqTool tool = new SearchFaqTool(new InMemoryFaqRepository());
+
+    @Test
+    void returnsSuccessForKnownFaqKeyword() {
+        ToolResult result = tool.execute(new SearchFaqTool.Input("환불 며칠 걸려요?"));
+
+        assertThat(result.ok()).isTrue();
+        assertThat(result.data())
+                .startsWith("Q: ")
+                .contains("환불")
+                .contains("A: ");
+    }
+
+    @Test
+    void returnsValidationErrorWhenQuestionMissing() {
+        ToolResult result = tool.execute(new SearchFaqTool.Input(""));
+
+        assertThat(result.ok()).isFalse();
+        assertThat(result.errorCategory()).isEqualTo(ToolErrorCategory.VALIDATION);
+        assertThat(result.isRetryable()).isFalse();
+    }
+
+    @Test
+    void returnsValidationErrorWhenQuestionNull() {
+        ToolResult result = tool.execute(new SearchFaqTool.Input(null));
+
+        assertThat(result.ok()).isFalse();
+        assertThat(result.errorCategory()).isEqualTo(ToolErrorCategory.VALIDATION);
+    }
+
+    @Test
+    void returnsNotFoundForUnknownQuestionAndRedirectsToSiblingTool() {
+        ToolResult result = tool.execute(new SearchFaqTool.Input("우주선 발사 절차 알려주세요"));
+
+        assertThat(result.ok()).isFalse();
+        assertThat(result.errorCategory()).isEqualTo(ToolErrorCategory.NOT_FOUND);
+        assertThat(result.isRetryable()).isFalse();
+        // 가이드 4번: NOT_FOUND 시 형제 도구로 폴백 안내가 있어야 함
+        assertThat(result.errorMessage()).contains("search_manual");
+    }
+
+    @Test
+    void exposesAllSurfaceFieldsForLlm() {
+        assertThat(tool.name()).isEqualTo("search_faq");
+        assertThat(tool.description()).isNotBlank();
+        assertThat(tool.whenToUse()).isNotBlank();
+        assertThat(tool.inputType()).isEqualTo(SearchFaqTool.Input.class);
+        assertThat(tool.inputSchema()).contains("question");
+        assertThat(tool.successOutputHint()).isNotBlank();
+        assertThat(tool.failureBehavior()).contains("NOT_FOUND");
+    }
+
+    @Test
+    void usageBoundaryDifferentiatesFromSimilarTool() {
+        // 가이드: 유사 기능 도구가 있을 때 boundary가 명확해야 모델이 잘못 고르지 않음
+        assertThat(tool.usageBoundary())
+                .contains("Do NOT use")
+                .contains("search_manual")  // 더 자세한 정책은 search_manual로
+                .contains("check_order_status");  // 주문 데이터는 check_order_status로
+    }
+}


### PR DESCRIPTION
Closes #11
Stacked on #10 → #8. base는 feat/tool-description-completeness이며, 상위 PR들이 머지되면 자동으로 main으로 변경됩니다.

## Summary
- **3번째 도구** `search_faq` 추가 (큐레이션된 단답 FAQ 검색)
- `InMemoryFaqRepository`로 데모 FAQ 10건 시딩 (환불·배송·탈퇴·쿠폰 등)
- 세 도구의 `usageBoundary`가 서로를 가리키도록 갱신
- 시스템 프롬프트 Guidelines에 도구 선택 규칙 한 줄 추가
- 통합 테스트로 "FAQ 매칭 실패 → search_manual 자동 폴백" 흐름 회귀 보호

## 동기
가이드 1단계: **"3~4개의 도구를 정의한다. 최소 2개는 유사한 기능을 가지도록 설계하여 설명의 차별화가 왜 중요한지 직접 확인한다."** PR #10에서 `usageBoundary`를 도입했지만, 유사 기능 도구가 없어 실제 차별화 압력이 없었음.

## 도구 차별화

| 도구 | 무엇을 반환 | 언제 호출 |
|---|---|---|
| `search_faq` | 큐레이션 짧은 Q&A 1개 | 자주 묻는 단순 질문 (환불 며칠 / 회원 탈퇴 등) |
| `search_manual` | 정책 원문 청크 N개 (RAG) | 정확한 조항/예외/세부 절차 |
| `check_order_status` | 특정 주문 데이터 | 고객이 주문 ID 명시 |

세 도구가 모두 "정보를 가져온다"는 공통점이 있어, **`usageBoundary`의 명확성이 도구 선택 정확도를 좌우**하는 환경이 만들어졌습니다.

## 변경 파일
- `faq/InMemoryFaqRepository.java` *(신규)* — 데모 FAQ 10건 + 키워드 매칭
- `analysis/agent/tool/SearchFaqTool.java` *(신규)* — `AgentTool<Input>` 구현
- `analysis/agent/tool/SearchManualTool.java`, `CheckOrderStatusTool.java` — `usageBoundary`에 search_faq 상호 참조 추가
- `analysis/agent/InquiryAgentService.java` — 도구 목록 [faq, manual, order] + `faqRepository` 의존성
- `analysis/application/PromptFactory.java` — Guidelines에 도구 선택 규칙 한 줄
- 테스트: `SearchFaqToolTest` 6개 신규 + 에이전트 통합 2개 추가
- `README.md` — 시스템 아키텍처에 FaqTool 노드, 설계 결정 #12, 프로젝트 구조

## 통합 테스트 시나리오
| 케이스 | 흐름 | 검증 |
|---|---|---|
| FAQ 즉답 | search_faq("환불 며칠?") → finalAnswer | search_manual 호출 없이 1스텝 종료 |
| FAQ 미스 후 폴백 | search_faq("우주선 발사") → NOT_FOUND → search_manual → finalAnswer | 첫 observation에 NOT_FOUND + "search_manual" 안내 명시 / 두 번째 스텝이 자동 폴백 |

## Test plan
- [x] `./gradlew test --tests "com.aicsassistant.analysis.agent.*"` — 40/40 통과
  - `SearchFaqToolTest` 6 (신규)
  - `InquiryAgentServiceTest` 13 (기존 11 + 통합 2)
  - 그 외 영향 없음
- [ ] (수동) Railway 배포 후 실제 LLM이 "환불 며칠?" → search_faq, "환불 분쟁 시 소비자보호법 조항" → search_manual로 정확히 라우팅하는지 관찰

## 가이드 5개 항목 최종 매핑 (이 PR + 모든 stacked PR 머지 후)
1. ✅ 다중 도구 정의 (3개 + 유사 기능 차별화) ← 이 PR
2. ✅ 에이전트 루프 / stop_reason 분기
3. ✅ 구조화된 에러 응답
4. ✅ 프로그래밍 가드
5. ✅ 다중 관심사 메시지 처리

추가로 *Tool Interface Design* 가이드의 좋은 도구 설명 4요소 모두 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)