### PR TITLE
검색 결과 신뢰도 향상: 유사도 threshold 및 score 노출

### DIFF
--- a/src/main/java/com/aicsassistant/analysis/application/ManualRetrievalService.java
+++ b/src/main/java/com/aicsassistant/analysis/application/ManualRetrievalService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 public class ManualRetrievalService {
 
     private static final int DEFAULT_TOP_K = 5;
+    private static final double MIN_SIMILARITY_SCORE = 0.75;
 
     private final JdbcTemplate jdbcTemplate;
     private final EmbeddingClient embeddingClient;
@@ -24,10 +25,10 @@ public class ManualRetrievalService {
         List<Double> queryEmbedding = embeddingClient.embed(inquiryContent);
         if (queryEmbedding != null && !queryEmbedding.isEmpty()) {
             try {
-                List<RetrievedManualChunkDto> vectorResults = findByVector(queryEmbedding);
-                if (!vectorResults.isEmpty()) {
-                    return vectorResults;
+                if (!hasActiveEmbeddings()) {
+                    return findFallback();
                 }
+                return findByVector(queryEmbedding);
             } catch (DataAccessException ignored) {
                 // Fallback path is used when vector dimensions/data are not ready.
             }
@@ -46,15 +47,31 @@ public class ManualRetrievalService {
                     mc.chunk_index,
                     mc.document_version,
                     mc.token_count,
-                    mc.content
+                    mc.content,
+                    (1 - (mc.embedding <=> cast(? as vector))) as similarity_score
                 from manual_chunk mc
                 join manual_document md on md.id = mc.manual_document_id
                 where md.active = true
                   and mc.active = true
                   and mc.embedding is not null
+                  and (1 - (mc.embedding <=> cast(? as vector))) >= ?
                 order by mc.embedding <=> cast(? as vector), mc.id
                 limit ?
-                """, pgvectorRowMapper, vectorLiteral, DEFAULT_TOP_K);
+                """, pgvectorRowMapper, vectorLiteral, vectorLiteral, MIN_SIMILARITY_SCORE, vectorLiteral, DEFAULT_TOP_K);
+    }
+
+    private boolean hasActiveEmbeddings() {
+        Boolean exists = jdbcTemplate.queryForObject("""
+                select exists (
+                    select 1
+                    from manual_chunk mc
+                    join manual_document md on md.id = mc.manual_document_id
+                    where md.active = true
+                      and mc.active = true
+                      and mc.embedding is not null
+                )
+                """, Boolean.class);
+        return Boolean.TRUE.equals(exists);
     }
 
     private List<RetrievedManualChunkDto> findFallback() {
@@ -67,7 +84,8 @@ public class ManualRetrievalService {
                     mc.chunk_index,
                     mc.document_version,
                     mc.token_count,
-                    mc.content
+                    mc.content,
+                    null::float8 as similarity_score
                 from manual_chunk mc
                 join manual_document md on md.id = mc.manual_document_id
                 where md.active = true

--- a/src/main/java/com/aicsassistant/analysis/dto/RetrievedManualChunkDto.java
+++ b/src/main/java/com/aicsassistant/analysis/dto/RetrievedManualChunkDto.java
@@ -8,6 +8,19 @@ public record RetrievedManualChunkDto(
         int chunkIndex,
         int documentVersion,
         int tokenCount,
-        String content
+        String content,
+        Double similarityScore
 ) {
+    public RetrievedManualChunkDto(
+            Long id,
+            Long manualDocumentId,
+            String manualDocumentTitle,
+            String manualCategory,
+            int chunkIndex,
+            int documentVersion,
+            int tokenCount,
+            String content
+    ) {
+        this(id, manualDocumentId, manualDocumentTitle, manualCategory, chunkIndex, documentVersion, tokenCount, content, null);
+    }
 }

--- a/src/main/java/com/aicsassistant/analysis/infra/vector/PgvectorRowMapper.java
+++ b/src/main/java/com/aicsassistant/analysis/infra/vector/PgvectorRowMapper.java
@@ -19,7 +19,8 @@ public class PgvectorRowMapper implements RowMapper<RetrievedManualChunkDto> {
                 rs.getInt("chunk_index"),
                 rs.getInt("document_version"),
                 rs.getInt("token_count"),
-                rs.getString("content")
+                rs.getString("content"),
+                (Double) rs.getObject("similarity_score")
         );
     }
 }


### PR DESCRIPTION
Closes #15

## 변경
- `ManualRetrievalService`에 `MIN_SIMILARITY_SCORE = 0.75` 도입
  - 임계값 미만 chunk는 결과에서 제외
- 활성 임베딩 존재 여부 선체크 후 fallback 분기 명확화
- `(1 - cosine distance)`를 `similarityScore`로 DTO에 노출
- `PgvectorRowMapper`가 `similarity_score` 컬럼 매핑

## 기대 효과
- 근거 부족 케이스에서 빈 결과 → 상담사 인계 플로우 자연스럽게 연결
- 검색 결과 score를 디버깅/평가에 활용 가능

## 검증
- 기존 단위 테스트 통과
- 평가 인프라(별도 PR)에서 score 노출 및 threshold cut 동작 검증