### PR TITLE
RAG 검색 품질 평가 인프라 구축

### DIFF
--- a/src/main/java/com/aicsassistant/analysis/application/ManualRetrievalService.java
+++ b/src/main/java/com/aicsassistant/analysis/application/ManualRetrievalService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 public class ManualRetrievalService {
 
     private static final int DEFAULT_TOP_K = 5;
+    private static final double MIN_SIMILARITY_SCORE = 0.75;
 
     private final JdbcTemplate jdbcTemplate;
     private final EmbeddingClient embeddingClient;
@@ -24,10 +25,10 @@ public class ManualRetrievalService {
         List<Double> queryEmbedding = embeddingClient.embed(inquiryContent);
         if (queryEmbedding != null && !queryEmbedding.isEmpty()) {
             try {
-                List<RetrievedManualChunkDto> vectorResults = findByVector(queryEmbedding);
-                if (!vectorResults.isEmpty()) {
-                    return vectorResults;
+                if (!hasActiveEmbeddings()) {
+                    return findFallback();
                 }
+                return findByVector(queryEmbedding);
             } catch (DataAccessException ignored) {
                 // Fallback path is used when vector dimensions/data are not ready.
             }
@@ -46,15 +47,31 @@ public class ManualRetrievalService {
                     mc.chunk_index,
                     mc.document_version,
                     mc.token_count,
-                    mc.content
+                    mc.content,
+                    (1 - (mc.embedding <=> cast(? as vector))) as similarity_score
                 from manual_chunk mc
                 join manual_document md on md.id = mc.manual_document_id
                 where md.active = true
                   and mc.active = true
                   and mc.embedding is not null
+                  and (1 - (mc.embedding <=> cast(? as vector))) >= ?
                 order by mc.embedding <=> cast(? as vector), mc.id
                 limit ?
-                """, pgvectorRowMapper, vectorLiteral, DEFAULT_TOP_K);
+                """, pgvectorRowMapper, vectorLiteral, vectorLiteral, MIN_SIMILARITY_SCORE, vectorLiteral, DEFAULT_TOP_K);
+    }
+
+    private boolean hasActiveEmbeddings() {
+        Boolean exists = jdbcTemplate.queryForObject("""
+                select exists (
+                    select 1
+                    from manual_chunk mc
+                    join manual_document md on md.id = mc.manual_document_id
+                    where md.active = true
+                      and mc.active = true
+                      and mc.embedding is not null
+                )
+                """, Boolean.class);
+        return Boolean.TRUE.equals(exists);
     }
 
     private List<RetrievedManualChunkDto> findFallback() {
@@ -67,7 +84,8 @@ public class ManualRetrievalService {
                     mc.chunk_index,
                     mc.document_version,
                     mc.token_count,
-                    mc.content
+                    mc.content,
+                    null::float8 as similarity_score
                 from manual_chunk mc
                 join manual_document md on md.id = mc.manual_document_id
                 where md.active = true

--- a/src/main/java/com/aicsassistant/analysis/dto/RetrievedManualChunkDto.java
+++ b/src/main/java/com/aicsassistant/analysis/dto/RetrievedManualChunkDto.java
@@ -8,6 +8,19 @@ public record RetrievedManualChunkDto(
         int chunkIndex,
         int documentVersion,
         int tokenCount,
-        String content
+        String content,
+        Double similarityScore
 ) {
+    public RetrievedManualChunkDto(
+            Long id,
+            Long manualDocumentId,
+            String manualDocumentTitle,
+            String manualCategory,
+            int chunkIndex,
+            int documentVersion,
+            int tokenCount,
+            String content
+    ) {
+        this(id, manualDocumentId, manualDocumentTitle, manualCategory, chunkIndex, documentVersion, tokenCount, content, null);
+    }
 }

--- a/src/main/java/com/aicsassistant/analysis/infra/vector/PgvectorRowMapper.java
+++ b/src/main/java/com/aicsassistant/analysis/infra/vector/PgvectorRowMapper.java
@@ -19,7 +19,8 @@ public class PgvectorRowMapper implements RowMapper<RetrievedManualChunkDto> {
                 rs.getInt("chunk_index"),
                 rs.getInt("document_version"),
                 rs.getInt("token_count"),
-                rs.getString("content")
+                rs.getString("content"),
+                (Double) rs.getObject("similarity_score")
         );
     }
 }

--- a/src/test/java/com/aicsassistant/analysis/application/ManualRetrievalEvaluationTest.java
+++ b/src/test/java/com/aicsassistant/analysis/application/ManualRetrievalEvaluationTest.java
@@ -1,0 +1,243 @@
+package com.aicsassistant.analysis.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aicsassistant.analysis.dto.RetrievedManualChunkDto;
+import com.aicsassistant.analysis.infra.llm.EmbeddingClient;
+import com.aicsassistant.support.PostgresVectorIntegrationTest;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * RAG 검색 품질 평가 (CSV 골든셋 기반).
+ *
+ * <p>FakeEmbedding은 케이스의 difficulty에 따라 의도적으로 강/약 신호를 만든다.
+ * 현재 baseline은 hard 케이스가 threshold(0.75)에 걸려 잡히지 않는 상태이며,
+ * 검색 로직(예: keyword hybrid)을 개선하면 hard 케이스가 통과되며 메트릭이 올라가야 한다.
+ */
+@SpringBootTest(properties = "app.ai.api-key=test-key")
+@Import(ManualRetrievalEvaluationTest.FakeEmbeddingConfig.class)
+class ManualRetrievalEvaluationTest extends PostgresVectorIntegrationTest {
+
+    private static final int EMBEDDING_DIMENSIONS = 1536;
+    private static final int DISTRACTOR_AXIS = 6;
+
+    private static final Map<String, Integer> TITLE_TO_AXIS = Map.of(
+            "환불 정책", 0,
+            "배송 정책", 1,
+            "교환 정책", 2,
+            "반품 정책", 3,
+            "회원 정책", 4,
+            "결제 정책", 5
+    );
+
+    private static List<RagEvaluationCase> goldenCases;
+
+    @Autowired
+    ManualRetrievalService manualRetrievalService;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @BeforeAll
+    static void loadGoldenSet() {
+        goldenCases = RagGoldenSetLoader.load(Path.of("src/test/resources/eval/rag-golden-set.csv"));
+    }
+
+    @BeforeEach
+    void seedManualChunks() {
+        seedManualDocument(1L, "환불 정책", "REFUND",
+                "환불은 수령 후 7일 이내 신청할 수 있습니다. 단순 변심도 포장 미개봉 시 가능합니다.", 0);
+        seedManualDocument(2L, "배송 정책", "DELIVERY",
+                "배송 지연은 영업일 기준으로 확인하며 일정 기간 초과 시 보상 기준을 안내합니다.", 1);
+        seedManualDocument(3L, "교환 정책", "EXCHANGE",
+                "교환은 상품 수령 후 정해진 기간 내 접수할 수 있습니다.", 2);
+        seedManualDocument(4L, "반품 정책", "RETURN",
+                "반품 신청 시 원포장을 유지해주시고 회수 일정은 별도 안내드립니다.", 3);
+        seedManualDocument(5L, "회원 정책", "MEMBERSHIP",
+                "회원 등급은 최근 구매 금액 기준으로 산정합니다.", 4);
+        seedManualDocument(6L, "결제 정책", "PAYMENT",
+                "결제 수단은 신용카드, 계좌이체, 간편결제를 지원하며 현금영수증 발급이 가능합니다.", 5);
+    }
+
+    @Test
+    @DisplayName("positive 케이스의 Recall@3는 baseline 기준선을 넘어야 한다")
+    void positiveRecallMeetsBaseline() {
+        List<Integer> ranks = positiveCases().stream()
+                .map(this::rankExpectedManualTitle)
+                .toList();
+
+        double recallAt3 = RagRetrievalMetrics.recallAt(ranks, 3);
+        double mrr = RagRetrievalMetrics.meanReciprocalRank(ranks);
+
+        // baseline: easy/medium 통과(15) + hard 미통과(4) = 15/19 ≈ 0.789
+        assertThat(recallAt3).isGreaterThanOrEqualTo(0.75);
+        assertThat(mrr).isGreaterThanOrEqualTo(0.75);
+    }
+
+    @Test
+    @DisplayName("easy+medium 난이도는 모두 1순위로 잡혀야 한다")
+    void easyAndMediumAreAlwaysRetrievedAtRankOne() {
+        List<Integer> ranks = positiveCases().stream()
+                .filter(c -> c.difficulty() != RagEvaluationCase.Difficulty.HARD)
+                .map(this::rankExpectedManualTitle)
+                .toList();
+
+        assertThat(ranks).isNotEmpty();
+        assertThat(RagRetrievalMetrics.recallAt(ranks, 1)).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("negative 케이스는 threshold에 걸려 결과가 비어야 한다")
+    void negativeCasesProduceNoMatches() {
+        List<RagEvaluationCase> negatives = goldenCases.stream()
+                .filter(RagEvaluationCase::negative)
+                .toList();
+
+        assertThat(negatives).isNotEmpty();
+
+        List<Integer> retrievedCounts = negatives.stream()
+                .map(c -> manualRetrievalService.retrieve(c.query()).size())
+                .toList();
+
+        assertThat(RagRetrievalMetrics.noMatchAccuracy(retrievedCounts)).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("hard 케이스는 현재 baseline에서 잡히지 않는다 (개선 여지 가시화)")
+    void hardCasesAreCurrentlyFilteredOut() {
+        List<Integer> hardRanks = goldenCases.stream()
+                .filter(c -> !c.negative() && c.difficulty() == RagEvaluationCase.Difficulty.HARD)
+                .map(this::rankExpectedManualTitle)
+                .toList();
+
+        assertThat(hardRanks).isNotEmpty();
+        // 검색 품질 개선 시 이 테스트가 깨져야 하며 그때 새 baseline으로 갱신한다.
+        assertThat(RagRetrievalMetrics.recallAt(hardRanks, 3)).isLessThanOrEqualTo(0.25);
+    }
+
+    @Test
+    @DisplayName("검색 결과는 similarity score를 노출한다")
+    void retrievedChunksExposeSimilarityScore() {
+        List<RetrievedManualChunkDto> retrieved = manualRetrievalService.retrieve("환불 기간 알려줘");
+
+        assertThat(retrieved).isNotEmpty();
+        assertThat(retrieved.get(0).manualDocumentTitle()).isEqualTo("환불 정책");
+        assertThat(retrieved.get(0).similarityScore()).isNotNull();
+        assertThat(retrieved.get(0).similarityScore()).isGreaterThanOrEqualTo(0.75);
+    }
+
+    private List<RagEvaluationCase> positiveCases() {
+        return goldenCases.stream().filter(c -> !c.negative()).toList();
+    }
+
+    private int rankExpectedManualTitle(RagEvaluationCase evaluationCase) {
+        List<RetrievedManualChunkDto> retrieved = manualRetrievalService.retrieve(evaluationCase.query());
+
+        for (int i = 0; i < retrieved.size(); i++) {
+            if (retrieved.get(i).manualDocumentTitle().equals(evaluationCase.expectedManualTitle())) {
+                return i + 1;
+            }
+        }
+        return RagRetrievalMetrics.NOT_FOUND_RANK;
+    }
+
+    private void seedManualDocument(Long id, String title, String category, String content, int embeddingAxis) {
+        LocalDateTime now = LocalDateTime.now();
+        jdbcTemplate.update("""
+                insert into manual_document (id, title, category, content, version, active, created_at, updated_at)
+                values (?, ?, ?, ?, ?, ?, ?, ?)
+                """, id, title, category, content, 1, true, now, now);
+
+        jdbcTemplate.update("""
+                insert into manual_chunk (
+                    id, manual_document_id, chunk_index, document_version, content, token_count, embedding, active, created_at
+                ) values (?, ?, ?, ?, ?, ?, cast(? as vector), ?, ?)
+                """,
+                id,
+                id,
+                0,
+                1,
+                content,
+                content.split("\\s+").length,
+                singleAxisVectorLiteral(embeddingAxis),
+                true,
+                now
+        );
+    }
+
+    private static String singleAxisVectorLiteral(int activeAxis) {
+        StringBuilder vector = new StringBuilder("[");
+        for (int i = 0; i < EMBEDDING_DIMENSIONS; i++) {
+            if (i > 0) {
+                vector.append(',');
+            }
+            vector.append(i == activeAxis ? "1.0" : "0.0");
+        }
+        return vector.append(']').toString();
+    }
+
+    @TestConfiguration
+    static class FakeEmbeddingConfig {
+
+        @Bean
+        @Primary
+        EmbeddingClient embeddingClient() {
+            Map<String, List<Double>> embeddingByQuery = buildEmbeddingMap();
+            return text -> embeddingByQuery.getOrDefault(text, uniformNoiseVector());
+        }
+
+        private static Map<String, List<Double>> buildEmbeddingMap() {
+            List<RagEvaluationCase> cases = RagGoldenSetLoader.load(
+                    Path.of("src/test/resources/eval/rag-golden-set.csv"));
+
+            Map<String, List<Double>> map = new HashMap<>();
+            for (RagEvaluationCase c : cases) {
+                map.put(c.query(), vectorFor(c));
+            }
+            return map;
+        }
+
+        private static List<Double> vectorFor(RagEvaluationCase c) {
+            if (c.negative()) {
+                return uniformNoiseVector();
+            }
+            int axis = TITLE_TO_AXIS.get(c.expectedManualTitle());
+            return switch (c.difficulty()) {
+                case EASY -> sparseVector(Map.of(axis, 1.0));
+                case MEDIUM -> sparseVector(Map.of(axis, 0.9, DISTRACTOR_AXIS, 0.4));
+                case HARD -> sparseVector(Map.of(axis, 0.6, DISTRACTOR_AXIS, 0.7));
+            };
+        }
+
+        private static List<Double> sparseVector(Map<Integer, Double> axisWeights) {
+            Double[] vector = new Double[EMBEDDING_DIMENSIONS];
+            for (int i = 0; i < EMBEDDING_DIMENSIONS; i++) {
+                vector[i] = axisWeights.getOrDefault(i, 0.0);
+            }
+            return List.of(vector);
+        }
+
+        private static List<Double> uniformNoiseVector() {
+            Double[] vector = new Double[EMBEDDING_DIMENSIONS];
+            for (int i = 0; i < EMBEDDING_DIMENSIONS; i++) {
+                vector[i] = TITLE_TO_AXIS.containsValue(i) ? 0.05 : 0.0;
+            }
+            return List.of(vector);
+        }
+    }
+}

--- a/src/test/java/com/aicsassistant/analysis/application/RagEvaluationCase.java
+++ b/src/test/java/com/aicsassistant/analysis/application/RagEvaluationCase.java
@@ -1,0 +1,22 @@
+package com.aicsassistant.analysis.application;
+
+import java.util.List;
+
+record RagEvaluationCase(
+        String query,
+        String category,
+        Difficulty difficulty,
+        String expectedManualTitle,
+        List<String> expectedChunkKeywords,
+        String answerMustInclude,
+        boolean negative
+) {
+
+    enum Difficulty {
+        EASY, MEDIUM, HARD;
+
+        static Difficulty parse(String raw) {
+            return Difficulty.valueOf(raw.trim().toUpperCase());
+        }
+    }
+}

--- a/src/test/java/com/aicsassistant/analysis/application/RagGoldenSetLoader.java
+++ b/src/test/java/com/aicsassistant/analysis/application/RagGoldenSetLoader.java
@@ -1,0 +1,82 @@
+package com.aicsassistant.analysis.application;
+
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+final class RagGoldenSetLoader {
+
+    private static final int EXPECTED_COLUMNS = 7;
+    private static final String MULTI_VALUE_DELIMITER = "\\|";
+
+    private RagGoldenSetLoader() {
+    }
+
+    static List<RagEvaluationCase> load(Path path) {
+        try {
+            return Files.readAllLines(path).stream()
+                    .skip(1)
+                    .filter(line -> !line.isBlank())
+                    .map(RagGoldenSetLoader::parseLine)
+                    .toList();
+        } catch (java.io.IOException e) {
+            throw new UncheckedIOException("Failed to load RAG golden set: " + path, e);
+        }
+    }
+
+    private static RagEvaluationCase parseLine(String line) {
+        String[] columns = splitCsv(line);
+        if (columns.length != EXPECTED_COLUMNS) {
+            throw new IllegalArgumentException(
+                    "RAG golden set line must have " + EXPECTED_COLUMNS + " columns but was " + columns.length + ": " + line);
+        }
+
+        boolean negative = Boolean.parseBoolean(columns[6].trim());
+        String expectedTitle = columns[3].trim();
+        String answerMustInclude = columns[5].trim();
+
+        return new RagEvaluationCase(
+                columns[0].trim(),
+                columns[1].trim(),
+                RagEvaluationCase.Difficulty.parse(columns[2]),
+                expectedTitle.isEmpty() ? null : expectedTitle,
+                parseMultiValue(columns[4]),
+                answerMustInclude.isEmpty() ? null : answerMustInclude,
+                negative
+        );
+    }
+
+    private static List<String> parseMultiValue(String raw) {
+        String trimmed = raw.trim();
+        if (trimmed.isEmpty()) {
+            return List.of();
+        }
+        return Arrays.stream(trimmed.split(MULTI_VALUE_DELIMITER))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .toList();
+    }
+
+    private static String[] splitCsv(String line) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+
+        for (int i = 0; i < line.length(); i++) {
+            char ch = line.charAt(i);
+            if (ch == '"') {
+                inQuotes = !inQuotes;
+            } else if (ch == ',' && !inQuotes) {
+                result.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(ch);
+            }
+        }
+        result.add(current.toString());
+        return result.toArray(new String[0]);
+    }
+}

--- a/src/test/java/com/aicsassistant/analysis/application/RagRetrievalMetrics.java
+++ b/src/test/java/com/aicsassistant/analysis/application/RagRetrievalMetrics.java
@@ -1,0 +1,47 @@
+package com.aicsassistant.analysis.application;
+
+import java.util.List;
+
+final class RagRetrievalMetrics {
+
+    static final int NOT_FOUND_RANK = Integer.MAX_VALUE;
+
+    private RagRetrievalMetrics() {
+    }
+
+    static double recallAt(List<Integer> ranks, int k) {
+        if (ranks.isEmpty()) {
+            return 0.0;
+        }
+
+        long hits = ranks.stream()
+                .filter(rank -> rank > 0 && rank <= k)
+                .count();
+        return hits / (double) ranks.size();
+    }
+
+    static double meanReciprocalRank(List<Integer> ranks) {
+        if (ranks.isEmpty()) {
+            return 0.0;
+        }
+
+        double total = ranks.stream()
+                .mapToDouble(rank -> rank == NOT_FOUND_RANK ? 0.0 : 1.0 / rank)
+                .sum();
+        return total / ranks.size();
+    }
+
+    /**
+     * Negative 케이스에서 검색 결과가 비어 있는지(threshold로 컷되는지) 비율.
+     */
+    static double noMatchAccuracy(List<Integer> retrievedCounts) {
+        if (retrievedCounts.isEmpty()) {
+            return 0.0;
+        }
+
+        long correctlyEmpty = retrievedCounts.stream()
+                .filter(count -> count == 0)
+                .count();
+        return correctlyEmpty / (double) retrievedCounts.size();
+    }
+}

--- a/src/test/resources/eval/rag-golden-set.csv
+++ b/src/test/resources/eval/rag-golden-set.csv
@@ -1,0 +1,23 @@
+query,category,difficulty,expectedManualTitle,expectedChunkKeywords,answerMustInclude,negative
+환불 기간 알려줘,REFUND,easy,환불 정책,환불|7일,7일,false
+환불 신청 어떻게 해요,REFUND,easy,환불 정책,환불|신청,환불,false
+돈 돌려받을 수 있나요,REFUND,medium,환불 정책,환불|7일,7일,false
+결제 취소하고 싶어요,REFUND,medium,환불 정책,환불|취소,환불,false
+어제 산 거 마음에 안 들어요,REFUND,hard,환불 정책,단순 변심|7일,7일,false
+배송 지연 보상 기준,DELIVERY,easy,배송 정책,지연|보상|영업일,영업일,false
+택배가 너무 늦어요,DELIVERY,medium,배송 정책,지연|영업일,영업일,false
+물건이 안 와요,DELIVERY,medium,배송 정책,지연|배송,영업일,false
+도착 예정일 한참 지났는데요,DELIVERY,hard,배송 정책,지연|보상,영업일,false
+교환 접수 조건 안내,EXCHANGE,easy,교환 정책,교환|기간,수령,false
+사이즈 다른 걸로 바꿔주세요,EXCHANGE,medium,교환 정책,교환|기간,수령,false
+받은 옷이 너무 작아요,EXCHANGE,hard,교환 정책,교환,수령,false
+반품 신청 방법 알려줘,RETURN,easy,반품 정책,반품|신청|포장,포장,false
+이거 다시 보낼게요,RETURN,medium,반품 정책,반품|포장,포장,false
+택배 도로 회수해갈 수 있나요,RETURN,hard,반품 정책,반품|회수,포장,false
+회원 등급 산정 기준,MEMBERSHIP,easy,회원 정책,등급|구매,구매 금액,false
+VIP 되려면 얼마 사야 해요,MEMBERSHIP,medium,회원 정책,등급|구매,구매 금액,false
+결제 수단 종류 안내,PAYMENT,easy,결제 정책,결제|카드,신용카드,false
+현금영수증 발급되나요,PAYMENT,medium,결제 정책,결제|영수증,신용카드,false
+오늘 점심 메뉴 추천해줘,GENERAL,easy,,,,true
+주식 사도 될까요,GENERAL,easy,,,,true
+서울 날씨 어때요,GENERAL,easy,,,,true


### PR DESCRIPTION
Closes #16

(이전 PR #19은 base 브랜치 삭제로 자동 닫힘. 동일 내용으로 재생성.)

## 변경
- CSV 골든셋 22 케이스 (`src/test/resources/eval/rag-golden-set.csv`)
  - 컬럼: `query, category, difficulty, expectedManualTitle, expectedChunkKeywords, answerMustInclude, negative`
  - 6 카테고리(REFUND/DELIVERY/EXCHANGE/RETURN/MEMBERSHIP/PAYMENT) × easy/medium/hard
  - negative 케이스 3개 (날씨/주식/점심)
- `RagGoldenSetLoader` 따옴표 포함 CSV 파서로 강화
- `RagRetrievalMetrics`: Recall@K, MRR, NoMatchAccuracy
- `ManualRetrievalEvaluationTest` 5개로 분할
  - positive Recall@3 baseline
  - easy+medium Recall@1
  - negative NoMatchAccuracy
  - hard Recall@3 (개선 여지 가시화용)
  - similarity score 노출 검증
- FakeEmbedding을 difficulty 기반으로 재설계
  - easy=순수 axis, medium=(0.9, 0.4), hard=(0.6, 0.7)
  - hard는 threshold 0.75에 의도적으로 컷되어 baseline 0으로 시작

## 현재 baseline 지표
| 지표 | 값 |
|---|---|
| positive Recall@3 | 0.789 |
| easy+medium Recall@1 | 1.0 |
| hard Recall@3 | 0.0 |
| NoMatchAccuracy | 1.0 |

## 후속 작업
- hybrid 검색(BM25 + vector) 도입 시 hard recall 개선 측정
- 카테고리 필터링 정확도 메트릭 추가