### PR TITLE
Langfuse 관측성 도입 (OpenTelemetry → OTLP)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.7.4'
     implementation 'com.pgvector:pgvector:0.1.6'
     implementation 'org.apache.pdfbox:pdfbox:3.0.3'
+    implementation platform('io.opentelemetry:opentelemetry-bom:1.46.0')
+    implementation 'io.opentelemetry:opentelemetry-api'
+    implementation 'io.opentelemetry:opentelemetry-sdk'
+    implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
+    implementation 'io.opentelemetry.semconv:opentelemetry-semconv:1.30.0-rc.1'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/aicsassistant/analysis/agent/InquiryAgentService.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/InquiryAgentService.java
@@ -17,6 +17,11 @@ import com.aicsassistant.order.InMemoryOrderRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +46,15 @@ public class InquiryAgentService {
 
     private static final int MAX_STEPS = 8;
 
+    private static final AttributeKey<String> ATTR_LF_TRACE_NAME = AttributeKey.stringKey("langfuse.trace.name");
+    private static final AttributeKey<String> ATTR_LF_INPUT = AttributeKey.stringKey("langfuse.observation.input");
+    private static final AttributeKey<String> ATTR_LF_OUTPUT = AttributeKey.stringKey("langfuse.observation.output");
+    private static final AttributeKey<Long> ATTR_INQUIRY_ID = AttributeKey.longKey("inquiry.id");
+    private static final AttributeKey<Long> ATTR_TOTAL_TOKENS = AttributeKey.longKey("agent.total_tokens");
+    private static final AttributeKey<Long> ATTR_STEP_COUNT = AttributeKey.longKey("agent.steps");
+    private static final AttributeKey<String> ATTR_AGENT_OUTCOME = AttributeKey.stringKey("agent.outcome");
+    private static final AttributeKey<String> ATTR_TOOL_NAME = AttributeKey.stringKey("agent.tool");
+
     private final LlmClient llmClient;
     private final ManualRetrievalService manualRetrievalService;
     private final PromptFactory promptFactory;
@@ -48,6 +62,7 @@ public class InquiryAgentService {
     private final InMemoryOrderRepository orderRepository;
     private final InMemoryFaqRepository faqRepository;
     private final List<ToolCallInterceptor> interceptors;
+    private final Tracer tracer;
 
     /**
      * @param inquiry         분석할 문의
@@ -58,6 +73,30 @@ public class InquiryAgentService {
         SearchManualTool searchTool = new SearchManualTool(manualRetrievalService);
         SearchFaqTool faqTool = new SearchFaqTool(faqRepository);
         List<AgentTool<?>> tools = List.of(faqTool, searchTool, orderTool);
+
+        Span agentSpan = tracer.spanBuilder("inquiry-analysis-agent")
+                .setAttribute(ATTR_LF_TRACE_NAME, "inquiry-analysis-agent")
+                .setAttribute(ATTR_INQUIRY_ID, inquiry.getId())
+                .setAttribute(ATTR_LF_INPUT, inquiry.getContent())
+                .startSpan();
+        try (Scope ignored = agentSpan.makeCurrent()) {
+            return runAgentLoop(inquiry, conversationHistory, tools, orderTool, searchTool, agentSpan);
+        } catch (RuntimeException e) {
+            agentSpan.setStatus(StatusCode.ERROR, e.getMessage());
+            agentSpan.recordException(e);
+            throw e;
+        } finally {
+            agentSpan.end();
+        }
+    }
+
+    private AgentResult runAgentLoop(
+            Inquiry inquiry,
+            List<InquiryMessage> conversationHistory,
+            List<AgentTool<?>> tools,
+            CheckOrderStatusTool orderTool,
+            SearchManualTool searchTool,
+            Span agentSpan) {
 
         List<ChatMessage> messages = new ArrayList<>();
         messages.add(ChatMessage.system(promptFactory.buildAgentSystemPrompt(tools)));
@@ -79,42 +118,61 @@ public class InquiryAgentService {
         ToolCallContext callContext = new ToolCallContext(inquiry.getId());
 
         for (int step = 0; step < MAX_STEPS; step++) {
-            LlmResponse llmResponse = llmClient.completeWithUsage(messages);
-            totalTokens += llmResponse.totalTokens();
-            String raw = llmResponse.content();
-            log.debug("[Agent inquiryId={} step={} tokens={}] raw={}", inquiry.getId(), step, llmResponse.totalTokens(), raw);
+            Span stepSpan = tracer.spanBuilder("agent-step")
+                    .setAttribute(AttributeKey.longKey("agent.step.index"), (long) step)
+                    .startSpan();
+            try (Scope ignored = stepSpan.makeCurrent()) {
+                LlmResponse llmResponse = llmClient.completeWithUsage(messages);
+                totalTokens += llmResponse.totalTokens();
+                String raw = llmResponse.content();
+                log.debug("[Agent inquiryId={} step={} tokens={}] raw={}", inquiry.getId(), step, llmResponse.totalTokens(), raw);
 
-            JsonNode node = parseJson(raw);
-            String thought = node.path("thought").asText("");
+                JsonNode node = parseJson(raw);
+                String thought = node.path("thought").asText("");
 
-            if (node.has("finalAnswer")) {
-                log.info("[Agent done] inquiryId={} steps={} totalTokens={}", inquiry.getId(), step, totalTokens);
-                return buildFinalAnswer(node, steps, searchTool.getCollectedChunks(), totalTokens);
+                if (node.has("finalAnswer")) {
+                    log.info("[Agent done] inquiryId={} steps={} totalTokens={}", inquiry.getId(), step, totalTokens);
+                    AgentResult.FinalAnswer result = buildFinalAnswer(node, steps, searchTool.getCollectedChunks(), totalTokens);
+                    agentSpan.setAttribute(ATTR_AGENT_OUTCOME, "final_answer");
+                    agentSpan.setAttribute(ATTR_LF_OUTPUT, result.answer());
+                    agentSpan.setAttribute(ATTR_TOTAL_TOKENS, totalTokens);
+                    agentSpan.setAttribute(ATTR_STEP_COUNT, (long) step + 1);
+                    return result;
+                }
+
+                if (node.has("followUpQuestion")) {
+                    String question = node.path("followUpQuestion").asText("").strip();
+                    log.info("[Agent followUp] inquiryId={} steps={} totalTokens={}", inquiry.getId(), step, totalTokens);
+                    agentSpan.setAttribute(ATTR_AGENT_OUTCOME, "follow_up");
+                    agentSpan.setAttribute(ATTR_LF_OUTPUT, question);
+                    agentSpan.setAttribute(ATTR_TOTAL_TOKENS, totalTokens);
+                    agentSpan.setAttribute(ATTR_STEP_COUNT, (long) step + 1);
+                    return new AgentResult.FollowUpQuestion(question, List.copyOf(steps), totalTokens);
+                }
+
+                String action = node.path("action").asText("");
+                JsonNode actionInput = node.path("actionInput");
+                stepSpan.setAttribute(ATTR_TOOL_NAME, action);
+
+                AgentTool<?> tool = resolveTool(tools, action);
+                ToolResult toolResult = invokeWithInterceptors(tool, action, actionInput, callContext, inquiry.getId(), step);
+
+                String observation = serializeObservation(toolResult);
+                log.info("[Agent inquiryId={} step={}] action={} ok={} category={} observation_len={}",
+                        inquiry.getId(), step, action, toolResult.ok(), toolResult.errorCategory(), observation.length());
+
+                // search_manual 스텝에는 이번 호출에서 가져온 문서 목록을 첨부
+                List<RetrievedManualChunkDto> stepChunks = (tool instanceof SearchManualTool s) ? s.getLastCallChunks() : List.of();
+                steps.add(new AgentStep(thought, action, actionInput.toString(), observation, stepChunks));
+                messages.add(ChatMessage.assistant(raw));
+                messages.add(ChatMessage.user("Observation:\n" + observation));
+            } finally {
+                stepSpan.end();
             }
-
-            if (node.has("followUpQuestion")) {
-                String question = node.path("followUpQuestion").asText("").strip();
-                log.info("[Agent followUp] inquiryId={} steps={} totalTokens={}", inquiry.getId(), step, totalTokens);
-                return new AgentResult.FollowUpQuestion(question, List.copyOf(steps), totalTokens);
-            }
-
-            String action = node.path("action").asText("");
-            JsonNode actionInput = node.path("actionInput");
-
-            AgentTool<?> tool = resolveTool(tools, action);
-            ToolResult toolResult = invokeWithInterceptors(tool, action, actionInput, callContext, inquiry.getId(), step);
-
-            String observation = serializeObservation(toolResult);
-            log.info("[Agent inquiryId={} step={}] action={} ok={} category={} observation_len={}",
-                    inquiry.getId(), step, action, toolResult.ok(), toolResult.errorCategory(), observation.length());
-
-            // search_manual 스텝에는 이번 호출에서 가져온 문서 목록을 첨부
-            List<RetrievedManualChunkDto> stepChunks = (tool instanceof SearchManualTool s) ? s.getLastCallChunks() : List.of();
-            steps.add(new AgentStep(thought, action, actionInput.toString(), observation, stepChunks));
-            messages.add(ChatMessage.assistant(raw));
-            messages.add(ChatMessage.user("Observation:\n" + observation));
         }
 
+        agentSpan.setAttribute(ATTR_AGENT_OUTCOME, "exceeded_max_steps");
+        agentSpan.setAttribute(ATTR_TOTAL_TOKENS, totalTokens);
         throw new IllegalStateException(
                 "Agent exceeded maximum steps (" + MAX_STEPS + ") for inquiryId=" + inquiry.getId());
     }

--- a/src/main/java/com/aicsassistant/analysis/application/ManualRetrievalService.java
+++ b/src/main/java/com/aicsassistant/analysis/application/ManualRetrievalService.java
@@ -2,6 +2,11 @@ package com.aicsassistant.analysis.application;
 
 import com.aicsassistant.analysis.dto.RetrievedManualChunkDto;
 import com.aicsassistant.analysis.infra.llm.EmbeddingClient;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -26,23 +31,63 @@ public class ManualRetrievalService {
     private static final double MIN_VECTOR_FLOOR_FOR_KEYWORD = 0.5;
     private static final int RRF_K = 60;
 
+    private static final AttributeKey<String> ATTR_LF_INPUT = AttributeKey.stringKey("langfuse.observation.input");
+    private static final AttributeKey<String> ATTR_LF_OUTPUT = AttributeKey.stringKey("langfuse.observation.output");
+    private static final AttributeKey<Long> ATTR_RESULT_COUNT = AttributeKey.longKey("retrieval.result_count");
+    private static final AttributeKey<String> ATTR_PATH = AttributeKey.stringKey("retrieval.path");
+
     private final JdbcTemplate jdbcTemplate;
     private final EmbeddingClient embeddingClient;
+    private final Tracer tracer;
 
     @Transactional(readOnly = true)
     public List<RetrievedManualChunkDto> retrieve(String inquiryContent) {
+        Span span = tracer.spanBuilder("rag.retrieve")
+                .setAttribute(ATTR_LF_INPUT, inquiryContent)
+                .startSpan();
+        try (Scope ignored = span.makeCurrent()) {
+            RetrievalOutcome outcome = doRetrieveWithPath(inquiryContent);
+            span.setAttribute(ATTR_PATH, outcome.path());
+            span.setAttribute(ATTR_RESULT_COUNT, (long) outcome.chunks().size());
+            span.setAttribute(ATTR_LF_OUTPUT, summarizeChunks(outcome.chunks()));
+            return outcome.chunks();
+        } catch (RuntimeException e) {
+            span.setStatus(StatusCode.ERROR, e.getMessage());
+            span.recordException(e);
+            throw e;
+        } finally {
+            span.end();
+        }
+    }
+
+    private RetrievalOutcome doRetrieveWithPath(String inquiryContent) {
         List<Double> queryEmbedding = embeddingClient.embed(inquiryContent);
         if (queryEmbedding != null && !queryEmbedding.isEmpty()) {
             try {
                 if (!hasActiveEmbeddings()) {
-                    return findFallback();
+                    return new RetrievalOutcome(findFallback(), "fallback_no_embeddings");
                 }
-                return findByHybrid(queryEmbedding, inquiryContent);
+                return new RetrievalOutcome(findByHybrid(queryEmbedding, inquiryContent), "hybrid");
             } catch (DataAccessException ignored) {
                 // Fallback path is used when vector dimensions/data are not ready.
             }
         }
-        return findFallback();
+        return new RetrievalOutcome(findFallback(), "fallback_query_error");
+    }
+
+    private record RetrievalOutcome(List<RetrievedManualChunkDto> chunks, String path) {
+    }
+
+    private String summarizeChunks(List<RetrievedManualChunkDto> chunks) {
+        if (chunks.isEmpty()) {
+            return "[]";
+        }
+        return chunks.stream()
+                .map(c -> String.format("{title=%s, vsim=%s, ksim=%s}",
+                        c.manualDocumentTitle(),
+                        c.similarityScore() == null ? "-" : String.format("%.3f", c.similarityScore()),
+                        c.keywordScore() == null ? "-" : String.format("%.3f", c.keywordScore())))
+                .collect(Collectors.joining(", ", "[", "]"));
     }
 
     private List<RetrievedManualChunkDto> findByHybrid(List<Double> queryEmbedding, String query) {

--- a/src/main/java/com/aicsassistant/analysis/infra/llm/OpenAiClient.java
+++ b/src/main/java/com/aicsassistant/analysis/infra/llm/OpenAiClient.java
@@ -3,6 +3,11 @@ package com.aicsassistant.analysis.infra.llm;
 import com.aicsassistant.common.config.AiProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -16,9 +21,22 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 public class OpenAiClient implements LlmClient, EmbeddingClient {
 
+    private static final AttributeKey<String> ATTR_LF_TYPE = AttributeKey.stringKey("langfuse.observation.type");
+    private static final AttributeKey<String> ATTR_LF_INPUT = AttributeKey.stringKey("langfuse.observation.input");
+    private static final AttributeKey<String> ATTR_LF_OUTPUT = AttributeKey.stringKey("langfuse.observation.output");
+    private static final AttributeKey<String> ATTR_GENAI_SYSTEM = AttributeKey.stringKey("gen_ai.system");
+    private static final AttributeKey<String> ATTR_GENAI_MODEL = AttributeKey.stringKey("gen_ai.request.model");
+    // OTel GenAI semconv는 prompt/completion(구) → input/output(신)으로 이동 중. 양쪽 다 세팅해 호환성 확보.
+    private static final AttributeKey<Long> ATTR_GENAI_PROMPT_TOKENS = AttributeKey.longKey("gen_ai.usage.prompt_tokens");
+    private static final AttributeKey<Long> ATTR_GENAI_COMPLETION_TOKENS = AttributeKey.longKey("gen_ai.usage.completion_tokens");
+    private static final AttributeKey<Long> ATTR_GENAI_INPUT_TOKENS = AttributeKey.longKey("gen_ai.usage.input_tokens");
+    private static final AttributeKey<Long> ATTR_GENAI_OUTPUT_TOKENS = AttributeKey.longKey("gen_ai.usage.output_tokens");
+    private static final AttributeKey<Long> ATTR_GENAI_TOTAL_TOKENS = AttributeKey.longKey("gen_ai.usage.total_tokens");
+
     private final WebClient webClient;
     private final AiProperties aiProperties;
     private final ObjectMapper objectMapper;
+    private final Tracer tracer;
 
     @Override
     public String complete(String prompt) {
@@ -27,60 +45,59 @@ public class OpenAiClient implements LlmClient, EmbeddingClient {
 
     @Override
     public String complete(List<ChatMessage> messages) {
-        String messagesJson = serializeMessages(messages);
-        JsonNode response = webClient.post()
-                .uri("https://api.openai.com/v1/chat/completions")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + aiProperties.getApiKey())
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue("""
-                        {
-                          "model": "%s",
-                          "messages": %s,
-                          "temperature": 0.1
-                        }
-                        """.formatted(aiProperties.getModel(), messagesJson))
-                .retrieve()
-                .bodyToMono(JsonNode.class)
-                .block();
-
-        if (response == null) {
-            throw new IllegalStateException("OpenAI chat completion returned empty response");
-        }
-        JsonNode content = response.path("choices").path(0).path("message").path("content");
-        if (content.isMissingNode() || content.asText().isBlank()) {
-            throw new IllegalStateException("OpenAI chat completion missing content");
-        }
-        return content.asText();
+        return completeWithUsage(messages).content();
     }
 
     @Override
     public LlmResponse completeWithUsage(List<ChatMessage> messages) {
         String messagesJson = serializeMessages(messages);
-        JsonNode response = webClient.post()
-                .uri("https://api.openai.com/v1/chat/completions")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + aiProperties.getApiKey())
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue("""
-                        {
-                          "model": "%s",
-                          "messages": %s,
-                          "temperature": 0.1
-                        }
-                        """.formatted(aiProperties.getModel(), messagesJson))
-                .retrieve()
-                .bodyToMono(JsonNode.class)
-                .block();
+        Span span = tracer.spanBuilder("openai.chat.completion")
+                .setAttribute(ATTR_LF_TYPE, "generation")
+                .setAttribute(ATTR_GENAI_SYSTEM, "openai")
+                .setAttribute(ATTR_GENAI_MODEL, aiProperties.getModel())
+                .setAttribute(ATTR_LF_INPUT, messagesJson)
+                .startSpan();
+        try (Scope ignored = span.makeCurrent()) {
+            JsonNode response = webClient.post()
+                    .uri("https://api.openai.com/v1/chat/completions")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + aiProperties.getApiKey())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("""
+                            {
+                              "model": "%s",
+                              "messages": %s,
+                              "temperature": 0.1
+                            }
+                            """.formatted(aiProperties.getModel(), messagesJson))
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
 
-        if (response == null) {
-            throw new IllegalStateException("OpenAI chat completion returned empty response");
+            if (response == null) {
+                throw new IllegalStateException("OpenAI chat completion returned empty response");
+            }
+            JsonNode content = response.path("choices").path(0).path("message").path("content");
+            if (content.isMissingNode() || content.asText().isBlank()) {
+                throw new IllegalStateException("OpenAI chat completion missing content");
+            }
+            int promptTokens = response.path("usage").path("prompt_tokens").asInt(0);
+            int completionTokens = response.path("usage").path("completion_tokens").asInt(0);
+            String contentText = content.asText();
+
+            span.setAttribute(ATTR_LF_OUTPUT, contentText);
+            span.setAttribute(ATTR_GENAI_PROMPT_TOKENS, promptTokens);
+            span.setAttribute(ATTR_GENAI_INPUT_TOKENS, promptTokens);
+            span.setAttribute(ATTR_GENAI_COMPLETION_TOKENS, completionTokens);
+            span.setAttribute(ATTR_GENAI_OUTPUT_TOKENS, completionTokens);
+            span.setAttribute(ATTR_GENAI_TOTAL_TOKENS, promptTokens + completionTokens);
+            return new LlmResponse(contentText, promptTokens, completionTokens);
+        } catch (RuntimeException e) {
+            span.setStatus(StatusCode.ERROR, e.getMessage());
+            span.recordException(e);
+            throw e;
+        } finally {
+            span.end();
         }
-        JsonNode content = response.path("choices").path(0).path("message").path("content");
-        if (content.isMissingNode() || content.asText().isBlank()) {
-            throw new IllegalStateException("OpenAI chat completion missing content");
-        }
-        int promptTokens = response.path("usage").path("prompt_tokens").asInt(0);
-        int completionTokens = response.path("usage").path("completion_tokens").asInt(0);
-        return new LlmResponse(content.asText(), promptTokens, completionTokens);
     }
 
     private String serializeMessages(List<ChatMessage> messages) {
@@ -96,34 +113,55 @@ public class OpenAiClient implements LlmClient, EmbeddingClient {
 
     @Override
     public List<Double> embed(String text) {
-        JsonNode response = webClient.post()
-                .uri("https://api.openai.com/v1/embeddings")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + aiProperties.getApiKey())
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue("""
-                        {
-                          "model": "%s",
-                          "input": %s
-                        }
-                        """.formatted(aiProperties.getEmbeddingModel(), toJsonString(text)))
-                .retrieve()
-                .bodyToMono(JsonNode.class)
-                .block();
+        Span span = tracer.spanBuilder("openai.embedding")
+                .setAttribute(ATTR_LF_TYPE, "generation")
+                .setAttribute(ATTR_GENAI_SYSTEM, "openai")
+                .setAttribute(ATTR_GENAI_MODEL, aiProperties.getEmbeddingModel())
+                .setAttribute(ATTR_LF_INPUT, text)
+                .startSpan();
+        try (Scope ignored = span.makeCurrent()) {
+            JsonNode response = webClient.post()
+                    .uri("https://api.openai.com/v1/embeddings")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + aiProperties.getApiKey())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("""
+                            {
+                              "model": "%s",
+                              "input": %s
+                            }
+                            """.formatted(aiProperties.getEmbeddingModel(), toJsonString(text)))
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
 
-        if (response == null) {
-            throw new IllegalStateException("OpenAI embedding returned empty response");
-        }
+            if (response == null) {
+                throw new IllegalStateException("OpenAI embedding returned empty response");
+            }
 
-        JsonNode vectorNode = response.path("data").path(0).path("embedding");
-        if (!vectorNode.isArray()) {
-            throw new IllegalStateException("OpenAI embedding missing vector");
-        }
+            JsonNode vectorNode = response.path("data").path(0).path("embedding");
+            if (!vectorNode.isArray()) {
+                throw new IllegalStateException("OpenAI embedding missing vector");
+            }
 
-        List<Double> vector = new ArrayList<>();
-        for (JsonNode dimension : vectorNode) {
-            vector.add(dimension.asDouble());
+            int promptTokens = response.path("usage").path("prompt_tokens").asInt(0);
+            int totalTokens = response.path("usage").path("total_tokens").asInt(promptTokens);
+
+            List<Double> vector = new ArrayList<>();
+            for (JsonNode dimension : vectorNode) {
+                vector.add(dimension.asDouble());
+            }
+            span.setAttribute(ATTR_LF_OUTPUT, "vector[" + vector.size() + "]");
+            span.setAttribute(ATTR_GENAI_PROMPT_TOKENS, promptTokens);
+            span.setAttribute(ATTR_GENAI_INPUT_TOKENS, promptTokens);
+            span.setAttribute(ATTR_GENAI_TOTAL_TOKENS, totalTokens);
+            return vector;
+        } catch (RuntimeException e) {
+            span.setStatus(StatusCode.ERROR, e.getMessage());
+            span.recordException(e);
+            throw e;
+        } finally {
+            span.end();
         }
-        return vector;
     }
 
     @Override

--- a/src/main/java/com/aicsassistant/common/config/LangfuseProperties.java
+++ b/src/main/java/com/aicsassistant/common/config/LangfuseProperties.java
@@ -1,0 +1,29 @@
+package com.aicsassistant.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.langfuse")
+public class LangfuseProperties {
+
+    private boolean enabled = true;
+    private String host = "https://jp.cloud.langfuse.com";
+    private String publicKey = "";
+    private String secretKey = "";
+    private String serviceName = "ai-cs-assistant";
+
+    public boolean isConfigured() {
+        return enabled
+                && publicKey != null && !publicKey.isBlank()
+                && secretKey != null && !secretKey.isBlank();
+    }
+
+    public String otlpTracesEndpoint() {
+        return host.replaceAll("/$", "") + "/api/public/otel/v1/traces";
+    }
+}

--- a/src/main/java/com/aicsassistant/common/observability/OpenTelemetryConfig.java
+++ b/src/main/java/com/aicsassistant/common/observability/OpenTelemetryConfig.java
@@ -1,0 +1,88 @@
+package com.aicsassistant.common.observability;
+
+import com.aicsassistant.common.config.LangfuseProperties;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SpanLimits;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.semconv.ServiceAttributes;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class OpenTelemetryConfig {
+
+    /** 단일 attribute 값 최대 길이. PII/payload bloat 방지용. */
+    private static final int MAX_ATTRIBUTE_VALUE_LENGTH = 8192;
+
+    @Bean(destroyMethod = "close")
+    public OpenTelemetrySdk openTelemetrySdk(LangfuseProperties props) {
+        if (!props.isConfigured()) {
+            log.info("Langfuse not configured (missing keys or disabled). Using no-op tracer provider.");
+            // 빈 SDK도 close 가능하므로 destroyMethod 지정에 문제 없음.
+            return OpenTelemetrySdk.builder().build();
+        }
+
+        String credentials = props.getPublicKey() + ":" + props.getSecretKey();
+        String basicAuth = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+
+        OtlpHttpSpanExporter exporter = OtlpHttpSpanExporter.builder()
+                .setEndpoint(props.otlpTracesEndpoint())
+                .addHeader("Authorization", "Basic " + basicAuth)
+                .setCompression("gzip")
+                .setTimeout(Duration.ofSeconds(5))
+                .build();
+
+        BatchSpanProcessor processor = BatchSpanProcessor.builder(exporter)
+                .setScheduleDelay(Duration.ofSeconds(2))
+                .setExporterTimeout(Duration.ofSeconds(5))
+                .setMaxQueueSize(2048)
+                .setMaxExportBatchSize(512)
+                .build();
+
+        SpanLimits spanLimits = SpanLimits.builder()
+                .setMaxAttributeValueLength(MAX_ATTRIBUTE_VALUE_LENGTH)
+                .build();
+
+        Resource resource = Resource.getDefault().merge(
+                Resource.create(Attributes.of(ServiceAttributes.SERVICE_NAME, props.getServiceName())));
+
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(processor)
+                .setResource(resource)
+                .setSpanLimits(spanLimits)
+                .build();
+
+        log.info("Langfuse OpenTelemetry exporter configured: {}", props.otlpTracesEndpoint());
+
+        return OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+    }
+
+    @Bean
+    public OpenTelemetry openTelemetry(OpenTelemetrySdk sdk, LangfuseProperties props) {
+        if (!props.isConfigured()) {
+            return OpenTelemetry.noop();
+        }
+        return sdk;
+    }
+
+    @Bean
+    public Tracer tracer(OpenTelemetry openTelemetry) {
+        return openTelemetry.getTracer("ai-cs-assistant", "0.0.1");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,12 @@ app:
     embedding-model: text-embedding-3-small
   slack:
     webhook-url: ${SLACK_WEBHOOK_URL:}
+  langfuse:
+    enabled: ${LANGFUSE_ENABLED:true}
+    host: ${LANGFUSE_HOST:https://jp.cloud.langfuse.com}
+    public-key: ${LANGFUSE_PUBLIC_KEY:}
+    secret-key: ${LANGFUSE_SECRET_KEY:}
+    service-name: ai-cs-assistant
 ---
 spring:
   config:

--- a/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTest.java
+++ b/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTest.java
@@ -14,6 +14,8 @@ import com.aicsassistant.faq.InMemoryFaqRepository;
 import com.aicsassistant.inquiry.domain.Inquiry;
 import com.aicsassistant.order.InMemoryOrderRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,7 @@ class InquiryAgentServiceTest {
     @Mock PromptFactory promptFactory;
 
     InquiryAgentService agentService;
+    Tracer noopTracer = OpenTelemetry.noop().getTracer("test");
 
     @BeforeEach
     void setUp() {
@@ -40,7 +43,8 @@ class InquiryAgentServiceTest {
                 new ObjectMapper(),
                 new InMemoryOrderRepository(),
                 new InMemoryFaqRepository(),
-                List.of()
+                List.of(),
+                noopTracer
         );
     }
 
@@ -123,7 +127,8 @@ class InquiryAgentServiceTest {
                                 false,
                                 "blocked-by-test"));
                     }
-                }));
+                }),
+                noopTracer);
         givenLlmResponds(
                 toolCall("search_manual", "{\"query\":\"환불\"}"),
                 finalAnswer("권한 부족으로 상담사에게 라우팅합니다.", "REFUND", "MEDIUM", true)
@@ -152,7 +157,8 @@ class InquiryAgentServiceTest {
                         return com.aicsassistant.analysis.agent.ToolResult.success(
                                 (result.data() == null ? "" : result.data()) + "\n[GUARD]");
                     }
-                }));
+                }),
+                noopTracer);
         givenLlmResponds(
                 toolCall("search_manual", "{\"query\":\"환불\"}"),
                 finalAnswer("ok", "GENERAL", "LOW", false)
@@ -319,7 +325,8 @@ class InquiryAgentServiceTest {
                                 false,
                                 "Tool call budget exhausted"));
                     }
-                }));
+                }),
+                noopTracer);
         givenLlmResponds(
                 toolCall("search_manual", "{\"query\":\"반품 정책\"}"),
                 finalAnswer(

--- a/src/test/java/com/aicsassistant/common/config/LangfusePropertiesTest.java
+++ b/src/test/java/com/aicsassistant/common/config/LangfusePropertiesTest.java
@@ -1,0 +1,66 @@
+package com.aicsassistant.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LangfusePropertiesTest {
+
+    @Test
+    void isConfigured_returnsFalse_whenDisabled() {
+        LangfuseProperties props = new LangfuseProperties();
+        props.setEnabled(false);
+        props.setPublicKey("pk");
+        props.setSecretKey("sk");
+
+        assertThat(props.isConfigured()).isFalse();
+    }
+
+    @Test
+    void isConfigured_returnsFalse_whenPublicKeyMissing() {
+        LangfuseProperties props = new LangfuseProperties();
+        props.setEnabled(true);
+        props.setPublicKey("");
+        props.setSecretKey("sk");
+
+        assertThat(props.isConfigured()).isFalse();
+    }
+
+    @Test
+    void isConfigured_returnsFalse_whenSecretKeyBlank() {
+        LangfuseProperties props = new LangfuseProperties();
+        props.setEnabled(true);
+        props.setPublicKey("pk");
+        props.setSecretKey("   ");
+
+        assertThat(props.isConfigured()).isFalse();
+    }
+
+    @Test
+    void isConfigured_returnsTrue_whenAllSet() {
+        LangfuseProperties props = new LangfuseProperties();
+        props.setEnabled(true);
+        props.setPublicKey("pk-lf-xxx");
+        props.setSecretKey("sk-lf-xxx");
+
+        assertThat(props.isConfigured()).isTrue();
+    }
+
+    @Test
+    void otlpTracesEndpoint_appendsPath_withoutDoubleSlash() {
+        LangfuseProperties props = new LangfuseProperties();
+        props.setHost("https://jp.cloud.langfuse.com/");
+
+        assertThat(props.otlpTracesEndpoint())
+                .isEqualTo("https://jp.cloud.langfuse.com/api/public/otel/v1/traces");
+    }
+
+    @Test
+    void otlpTracesEndpoint_appendsPath_whenNoTrailingSlash() {
+        LangfuseProperties props = new LangfuseProperties();
+        props.setHost("https://jp.cloud.langfuse.com");
+
+        assertThat(props.otlpTracesEndpoint())
+                .isEqualTo("https://jp.cloud.langfuse.com/api/public/otel/v1/traces");
+    }
+}


### PR DESCRIPTION
Closes #25

## 배경
`inquiry_analysis_log` 테이블에 토큰/latency/agent_steps 저장 중이지만 분석 시마다 SQL을 짜야 했다. LLM 운영에서 시각화/필터/집계가 부족 → Langfuse로 trace 시각화.

## 통합 방식 — 왜 OpenTelemetry인가
Langfuse 공식 가이드에 따르면 Java 전용 SDK가 없고 **OTLP endpoint**가 권장 경로다.

- **OpenTelemetry SDK (1.46.0)** 표준 사용
- `https://jp.cloud.langfuse.com/api/public/otel/v1/traces` 에 OTLP/HTTP로 export
- Basic Auth (`base64(public:secret)`)
- 벤더 lock-in 없음 (Langfuse 외 다른 OTel 백엔드도 즉시 가능)

## 인스트루먼테이션 위치

### 1. `OpenAiClient.completeWithUsage` — LLM 호출
- Span: `openai.chat.completion` (type=generation)
- Attributes: `gen_ai.system`, `gen_ai.request.model`
- 토큰: 구/신 OTel GenAI semconv 양쪽 세팅 (prompt/completion + input/output) — 비용 계산 호환성
- Langfuse: `langfuse.observation.input` (messages JSON), `langfuse.observation.output` (응답 텍스트)

### 2. `OpenAiClient.embed` — 임베딩 호출
- Span: `openai.embedding` (type=generation)
- Output에는 벡터 자체 대신 `vector[1536]` 차원 수만 (페이로드 절약)

### 3. `InquiryAgentService.run` — Agent 루프
- Parent span: `inquiry-analysis-agent`
  - `langfuse.trace.name`, `inquiry.id`, `agent.outcome`, `agent.total_tokens`, `agent.steps`
- Step별 sub-span: 이름 `agent-step` + `agent.step.index` attribute (집계 친화적 cardinality)
- `agent.tool` attribute로 호출 툴 추적
- 종료 상태: `final_answer` / `follow_up` / `exceeded_max_steps`

### 4. `ManualRetrievalService.retrieve` — RAG 검색
- Span: `rag.retrieve`
- `retrieval.path`: `hybrid` / `fallback_no_embeddings` / `fallback_query_error`
- `retrieval.result_count`
- Output: chunk 요약 `[{title, vsim=0.95, ksim=0.18}, ...]`

## 운영 안전 장치

| 항목 | 처리 |
|---|---|
| 키 없거나 disabled | `OpenTelemetry.noop()` fallback (기존 동작 무영향) |
| SDK 종료 시 trace 손실 | `@Bean(destroyMethod = "close")`로 Spring 종료 시 flush |
| Attribute value bloat / PII | `SpanLimits.maxAttributeValueLength = 8192` 자동 truncate |
| 네트워크 latency (JP region) | OTLP exporter gzip compression |
| 백프레셔 | BatchSpanProcessor maxQueueSize 2048, scheduleDelay 2s, exporterTimeout 5s |
| Langfuse 장애 시 | Batch processor에서 silently drop → 본 동작 영향 없음 |
| Charset 모호성 | Base64 인코딩 시 `StandardCharsets.UTF_8` 명시 |
| 기존 DB 로깅 | `inquiry_analysis_log` 병행 유지 |

## 환경변수 (`.env.local`)
```
LANGFUSE_ENABLED=true
LANGFUSE_HOST=https://jp.cloud.langfuse.com
LANGFUSE_PUBLIC_KEY=pk-lf-...
LANGFUSE_SECRET_KEY=sk-lf-...
```

## 검증
- 전체 **86 테스트 통과**
- `LangfuseProperties` 단위 테스트 6개 신규 (isConfigured 조합, endpoint URL trailing-slash 처리)
- noop tracer 경로로 키 없을 때 안전 동작 확인

## 로컬 검증 방법
1. `.env.local`에 키 셋업
2. `./gradlew bootRun --args='--spring.profiles.active=local'`
3. 유저 포털에서 문의 제출 → Langfuse Japan dashboard에서 trace 확인

## 후속
- README에 dashboard 스크린샷 첨부
- prompt versioning (Langfuse Prompts 활용 검토)
- evaluation runs (Langfuse Datasets 검토)