### PR TITLE
Langfuse trace에 session.id / user.id / tags 추가

### DIFF
--- a/src/main/java/com/aicsassistant/analysis/agent/InquiryAgentService.java
+++ b/src/main/java/com/aicsassistant/analysis/agent/InquiryAgentService.java
@@ -49,6 +49,9 @@ public class InquiryAgentService {
     private static final AttributeKey<String> ATTR_LF_TRACE_NAME = AttributeKey.stringKey("langfuse.trace.name");
     private static final AttributeKey<String> ATTR_LF_INPUT = AttributeKey.stringKey("langfuse.observation.input");
     private static final AttributeKey<String> ATTR_LF_OUTPUT = AttributeKey.stringKey("langfuse.observation.output");
+    private static final AttributeKey<String> ATTR_LF_SESSION_ID = AttributeKey.stringKey("langfuse.session.id");
+    private static final AttributeKey<String> ATTR_LF_USER_ID = AttributeKey.stringKey("langfuse.user.id");
+    private static final AttributeKey<List<String>> ATTR_LF_TAGS = AttributeKey.stringArrayKey("langfuse.trace.tags");
     private static final AttributeKey<Long> ATTR_INQUIRY_ID = AttributeKey.longKey("inquiry.id");
     private static final AttributeKey<Long> ATTR_TOTAL_TOKENS = AttributeKey.longKey("agent.total_tokens");
     private static final AttributeKey<Long> ATTR_STEP_COUNT = AttributeKey.longKey("agent.steps");
@@ -78,6 +81,9 @@ public class InquiryAgentService {
                 .setAttribute(ATTR_LF_TRACE_NAME, "inquiry-analysis-agent")
                 .setAttribute(ATTR_INQUIRY_ID, inquiry.getId())
                 .setAttribute(ATTR_LF_INPUT, inquiry.getContent())
+                .setAttribute(ATTR_LF_SESSION_ID, "inquiry-" + inquiry.getId())
+                .setAttribute(ATTR_LF_USER_ID, safeUserId(inquiry))
+                .setAttribute(ATTR_LF_TAGS, buildTags(inquiry))
                 .startSpan();
         try (Scope ignored = agentSpan.makeCurrent()) {
             return runAgentLoop(inquiry, conversationHistory, tools, orderTool, searchTool, agentSpan);
@@ -175,6 +181,22 @@ public class InquiryAgentService {
         agentSpan.setAttribute(ATTR_TOTAL_TOKENS, totalTokens);
         throw new IllegalStateException(
                 "Agent exceeded maximum steps (" + MAX_STEPS + ") for inquiryId=" + inquiry.getId());
+    }
+
+    static String safeUserId(Inquiry inquiry) {
+        String id = inquiry.getCustomerIdentifier();
+        return id == null || id.isBlank() ? "anonymous" : id;
+    }
+
+    static List<String> buildTags(Inquiry inquiry) {
+        List<String> tags = new ArrayList<>();
+        if (inquiry.getCategory() != null) {
+            tags.add("category:" + inquiry.getCategory().name());
+        }
+        if (inquiry.getUrgency() != null) {
+            tags.add("urgency:" + inquiry.getUrgency().name());
+        }
+        return tags;
     }
 
     private String buildInitialMessage(Inquiry inquiry, CheckOrderStatusTool orderTool) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,8 @@ app:
     webhook-url: ${SLACK_WEBHOOK_URL:}
   langfuse:
     enabled: ${LANGFUSE_ENABLED:true}
-    host: ${LANGFUSE_HOST:https://jp.cloud.langfuse.com}
+    # LANGFUSE_HOST는 deprecated. LANGFUSE_BASE_URL 사용 권장 — 점진적 마이그레이션 위해 둘 다 인식.
+    host: ${LANGFUSE_BASE_URL:${LANGFUSE_HOST:https://jp.cloud.langfuse.com}}
     public-key: ${LANGFUSE_PUBLIC_KEY:}
     secret-key: ${LANGFUSE_SECRET_KEY:}
     service-name: ai-cs-assistant

--- a/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTagsTest.java
+++ b/src/test/java/com/aicsassistant/analysis/agent/InquiryAgentServiceTagsTest.java
@@ -1,0 +1,66 @@
+package com.aicsassistant.analysis.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aicsassistant.inquiry.domain.Inquiry;
+import com.aicsassistant.inquiry.domain.InquiryCategory;
+import com.aicsassistant.inquiry.domain.UrgencyLevel;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Langfuse trace attribute 헬퍼(buildTags / safeUserId) 순수 함수 검증.
+ */
+class InquiryAgentServiceTagsTest {
+
+    @Test
+    void buildTags_returnsEmptyList_whenCategoryAndUrgencyNull() {
+        Inquiry inquiry = Inquiry.create("kim", "t", "c");
+
+        assertThat(InquiryAgentService.buildTags(inquiry)).isEmpty();
+    }
+
+    @Test
+    void buildTags_includesCategoryOnly_whenUrgencyNull() {
+        Inquiry inquiry = Inquiry.create("kim", "t", "c", InquiryCategory.REFUND, null);
+
+        assertThat(InquiryAgentService.buildTags(inquiry))
+                .containsExactly("category:REFUND");
+    }
+
+    @Test
+    void buildTags_includesUrgencyOnly_whenCategoryNull() {
+        Inquiry inquiry = Inquiry.create("kim", "t", "c", null, UrgencyLevel.HIGH);
+
+        assertThat(InquiryAgentService.buildTags(inquiry))
+                .containsExactly("urgency:HIGH");
+    }
+
+    @Test
+    void buildTags_includesBoth_inOrder() {
+        Inquiry inquiry = Inquiry.create("kim", "t", "c", InquiryCategory.EXCHANGE, UrgencyLevel.MEDIUM);
+
+        assertThat(InquiryAgentService.buildTags(inquiry))
+                .containsExactly("category:EXCHANGE", "urgency:MEDIUM");
+    }
+
+    @Test
+    void safeUserId_returnsAnonymous_whenCustomerNull() {
+        Inquiry inquiry = Inquiry.create(null, "t", "c");
+
+        assertThat(InquiryAgentService.safeUserId(inquiry)).isEqualTo("anonymous");
+    }
+
+    @Test
+    void safeUserId_returnsAnonymous_whenCustomerBlank() {
+        Inquiry inquiry = Inquiry.create("   ", "t", "c");
+
+        assertThat(InquiryAgentService.safeUserId(inquiry)).isEqualTo("anonymous");
+    }
+
+    @Test
+    void safeUserId_returnsRawId_whenCustomerSet() {
+        Inquiry inquiry = Inquiry.create("kim-minjun", "t", "c");
+
+        assertThat(InquiryAgentService.safeUserId(inquiry)).isEqualTo("kim-minjun");
+    }
+}


### PR DESCRIPTION
Closes #27

## 배경
PR #26으로 trace 자체는 잘 잡히지만 Langfuse UI의 1급 필터(Sessions / Users / Tags)를 못 쓰는 상태였다.

## 변경
`InquiryAgentService.run`의 parent span에 Langfuse 표준 attribute 추가:

| Attribute | 형태 | 값 | 효과 |
|---|---|---|---|
| `langfuse.session.id` | string | `"inquiry-{inquiryId}"` | 같은 문의의 multi-turn 분석을 한 세션으로 묶음 |
| `langfuse.user.id` | string | customer identifier (없으면 `"anonymous"`) | Users 뷰에서 고객별 사용 통계 |
| `langfuse.trace.tags` | **string array** | `["category:REFUND","urgency:HIGH"]` | 카테고리/긴급도별 필터 (Langfuse OTel spec: array attribute 형태 필수) |

### 부수 변경
- `application.yml` env var: `LANGFUSE_HOST` → `LANGFUSE_BASE_URL` 마이그레이션
  - `.env.local` / 다른 `*_BASE_URL` 패턴과 일관
  - 기존 키도 인식하도록 fallback 체인 (`${LANGFUSE_BASE_URL:${LANGFUSE_HOST:default}}`) — 점진적 전환

## Tag 처리
분석 이전 시점에는 `category`/`urgency`가 `null`일 수 있어 빈 배열이 들어감. AI 분석 후 set되면 다음 분석부터 태그 채워짐.

## 검증
- `InquiryAgentServiceTagsTest` 추가 (7 케이스)
  - buildTags: null/single/both 조합
  - safeUserId: null / blank / 정상 값
- 전체 **93 테스트 통과**
- 로컬에서 문의 제출 → Langfuse Sessions / Users / Tag 필터에서 확인