### PR TITLE
리팩토링: RAG 쿼리를 ManualChunkRetrievalRepository로 분리

### DIFF
--- a/src/main/java/com/aicsassistant/analysis/application/ManualRetrievalService.java
+++ b/src/main/java/com/aicsassistant/analysis/application/ManualRetrievalService.java
@@ -1,6 +1,8 @@
 package com.aicsassistant.analysis.application;
 
 import com.aicsassistant.analysis.dto.RetrievedManualChunkDto;
+import com.aicsassistant.analysis.dto.ScoredManualChunk;
+import com.aicsassistant.analysis.infra.ManualChunkRetrievalRepository;
 import com.aicsassistant.analysis.infra.llm.EmbeddingClient;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
@@ -8,15 +10,12 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +35,7 @@ public class ManualRetrievalService {
     private static final AttributeKey<Long> ATTR_RESULT_COUNT = AttributeKey.longKey("retrieval.result_count");
     private static final AttributeKey<String> ATTR_PATH = AttributeKey.stringKey("retrieval.path");
 
-    private final JdbcTemplate jdbcTemplate;
+    private final ManualChunkRetrievalRepository retrievalRepository;
     private final EmbeddingClient embeddingClient;
     private final Tracer tracer;
 
@@ -64,15 +63,15 @@ public class ManualRetrievalService {
         List<Double> queryEmbedding = embeddingClient.embed(inquiryContent);
         if (queryEmbedding != null && !queryEmbedding.isEmpty()) {
             try {
-                if (!hasActiveEmbeddings()) {
-                    return new RetrievalOutcome(findFallback(), "fallback_no_embeddings");
+                if (!retrievalRepository.hasActiveEmbeddings()) {
+                    return new RetrievalOutcome(retrievalRepository.findFallbackTopK(DEFAULT_TOP_K), "fallback_no_embeddings");
                 }
                 return new RetrievalOutcome(findByHybrid(queryEmbedding, inquiryContent), "hybrid");
             } catch (DataAccessException ignored) {
                 // Fallback path is used when vector dimensions/data are not ready.
             }
         }
-        return new RetrievalOutcome(findFallback(), "fallback_query_error");
+        return new RetrievalOutcome(retrievalRepository.findFallbackTopK(DEFAULT_TOP_K), "fallback_query_error");
     }
 
     private record RetrievalOutcome(List<RetrievedManualChunkDto> chunks, String path) {
@@ -91,21 +90,21 @@ public class ManualRetrievalService {
     }
 
     private List<RetrievedManualChunkDto> findByHybrid(List<Double> queryEmbedding, String query) {
-        List<Candidate> vectorCandidates = findVectorCandidates(queryEmbedding, FUSION_CANDIDATE_K);
-        List<Candidate> keywordCandidates = findKeywordCandidates(query, FUSION_CANDIDATE_K);
+        List<ScoredManualChunk> vectorCandidates = retrievalRepository.findVectorCandidates(queryEmbedding, FUSION_CANDIDATE_K);
+        List<ScoredManualChunk> keywordCandidates = findKeywordCandidatesPreprocessed(query);
 
         Map<Long, FusionEntry> byId = new LinkedHashMap<>();
         for (int i = 0; i < vectorCandidates.size(); i++) {
-            Candidate c = vectorCandidates.get(i);
-            FusionEntry entry = byId.computeIfAbsent(c.chunk.id(), k -> new FusionEntry(c.chunk));
+            ScoredManualChunk c = vectorCandidates.get(i);
+            FusionEntry entry = byId.computeIfAbsent(c.chunk().id(), k -> new FusionEntry(c.chunk()));
             entry.vectorRank = i + 1;
-            entry.vectorScore = c.score;
+            entry.vectorScore = c.score();
         }
         for (int i = 0; i < keywordCandidates.size(); i++) {
-            Candidate c = keywordCandidates.get(i);
-            FusionEntry entry = byId.computeIfAbsent(c.chunk.id(), k -> new FusionEntry(c.chunk));
+            ScoredManualChunk c = keywordCandidates.get(i);
+            FusionEntry entry = byId.computeIfAbsent(c.chunk().id(), k -> new FusionEntry(c.chunk()));
             entry.keywordRank = i + 1;
-            entry.keywordScore = c.score;
+            entry.keywordScore = c.score();
         }
 
         // P1 수정: keyword 후보가 vector top-K 밖이면 vectorScore가 기본값 0.0이라
@@ -120,57 +119,12 @@ public class ManualRetrievalService {
                 .toList();
     }
 
-    private List<Candidate> findVectorCandidates(List<Double> queryEmbedding, int limit) {
-        String vectorLiteral = toVectorLiteral(queryEmbedding);
-        return jdbcTemplate.query("""
-                select
-                    mc.id,
-                    mc.manual_document_id,
-                    md.title as manual_document_title,
-                    md.category as manual_document_category,
-                    mc.chunk_index,
-                    mc.document_version,
-                    mc.token_count,
-                    mc.content,
-                    (1 - (mc.embedding <=> cast(? as vector))) as score
-                from manual_chunk mc
-                join manual_document md on md.id = mc.manual_document_id
-                where md.active = true
-                  and mc.active = true
-                  and mc.embedding is not null
-                order by mc.embedding <=> cast(? as vector), mc.id
-                limit ?
-                """, scoredChunkRowMapper(), vectorLiteral, vectorLiteral, limit);
-    }
-
-    private List<Candidate> findKeywordCandidates(String query, int limit) {
+    private List<ScoredManualChunk> findKeywordCandidatesPreprocessed(String query) {
         String cleaned = KoreanQueryPreprocessor.forKeywordSearch(query);
         if (cleaned.isBlank()) {
             return List.of();
         }
-        // P2 수정: <% operator + <<-> distance를 써서 gin_trgm_ops GIN 인덱스 활용.
-        // <% operator의 임계값은 pg_trgm.word_similarity_threshold GUC로 제어.
-        // SET LOCAL은 트랜잭션 스코프에서만 유효하므로 retrieve()가 @Transactional이어야 한다.
-        jdbcTemplate.execute("set local pg_trgm.word_similarity_threshold = " + MIN_KEYWORD_SCORE);
-        return jdbcTemplate.query("""
-                select
-                    mc.id,
-                    mc.manual_document_id,
-                    md.title as manual_document_title,
-                    md.category as manual_document_category,
-                    mc.chunk_index,
-                    mc.document_version,
-                    mc.token_count,
-                    mc.content,
-                    word_similarity(cast(? as text), mc.content) as score
-                from manual_chunk mc
-                join manual_document md on md.id = mc.manual_document_id
-                where md.active = true
-                  and mc.active = true
-                  and cast(? as text) <% mc.content
-                order by cast(? as text) <<-> mc.content, mc.id
-                limit ?
-                """, scoredChunkRowMapper(), cleaned, cleaned, cleaned, limit);
+        return retrievalRepository.findKeywordCandidates(cleaned, MIN_KEYWORD_SCORE, FUSION_CANDIDATE_K);
     }
 
     private void augmentVectorScores(Map<Long, FusionEntry> byId, List<Double> queryEmbedding) {
@@ -182,18 +136,7 @@ public class ManualRetrievalService {
             return;
         }
 
-        String idCsv = missingIds.stream().map(String::valueOf).collect(Collectors.joining(","));
-        String vectorLiteral = toVectorLiteral(queryEmbedding);
-
-        Map<Long, Double> scores = new HashMap<>();
-        jdbcTemplate.query("""
-                select id, (1 - (embedding <=> cast(? as vector))) as score
-                from manual_chunk
-                where id in (%s) and embedding is not null
-                """.formatted(idCsv),
-                rs -> { scores.put(rs.getLong("id"), rs.getDouble("score")); },
-                vectorLiteral);
-
+        Map<Long, Double> scores = retrievalRepository.findVectorScoresByIds(missingIds, queryEmbedding);
         for (FusionEntry entry : byId.values()) {
             Double score = scores.get(entry.chunk.id());
             if (score != null) {
@@ -208,78 +151,6 @@ public class ManualRetrievalService {
         }
         return e.keywordScore >= MIN_KEYWORD_SCORE
                 && e.vectorScore >= MIN_VECTOR_FLOOR_FOR_KEYWORD;
-    }
-
-    private boolean hasActiveEmbeddings() {
-        Boolean exists = jdbcTemplate.queryForObject("""
-                select exists (
-                    select 1
-                    from manual_chunk mc
-                    join manual_document md on md.id = mc.manual_document_id
-                    where md.active = true
-                      and mc.active = true
-                      and mc.embedding is not null
-                )
-                """, Boolean.class);
-        return Boolean.TRUE.equals(exists);
-    }
-
-    private List<RetrievedManualChunkDto> findFallback() {
-        return jdbcTemplate.query("""
-                select
-                    mc.id,
-                    mc.manual_document_id,
-                    md.title as manual_document_title,
-                    md.category as manual_document_category,
-                    mc.chunk_index,
-                    mc.document_version,
-                    mc.token_count,
-                    mc.content
-                from manual_chunk mc
-                join manual_document md on md.id = mc.manual_document_id
-                where md.active = true
-                  and mc.active = true
-                order by mc.id, mc.chunk_index
-                limit ?
-                """, fallbackRowMapper(), DEFAULT_TOP_K);
-    }
-
-    private String toVectorLiteral(List<Double> vector) {
-        return vector.stream()
-                .map(String::valueOf)
-                .collect(Collectors.joining(",", "[", "]"));
-    }
-
-    private RowMapper<Candidate> scoredChunkRowMapper() {
-        return (rs, rowNum) -> {
-            RetrievedManualChunkDto chunk = new RetrievedManualChunkDto(
-                    rs.getLong("id"),
-                    rs.getLong("manual_document_id"),
-                    rs.getString("manual_document_title"),
-                    rs.getString("manual_document_category"),
-                    rs.getInt("chunk_index"),
-                    rs.getInt("document_version"),
-                    rs.getInt("token_count"),
-                    rs.getString("content")
-            );
-            return new Candidate(chunk, rs.getDouble("score"));
-        };
-    }
-
-    private RowMapper<RetrievedManualChunkDto> fallbackRowMapper() {
-        return (rs, rowNum) -> new RetrievedManualChunkDto(
-                rs.getLong("id"),
-                rs.getLong("manual_document_id"),
-                rs.getString("manual_document_title"),
-                rs.getString("manual_document_category"),
-                rs.getInt("chunk_index"),
-                rs.getInt("document_version"),
-                rs.getInt("token_count"),
-                rs.getString("content")
-        );
-    }
-
-    private record Candidate(RetrievedManualChunkDto chunk, double score) {
     }
 
     private static final class FusionEntry {

--- a/src/main/java/com/aicsassistant/analysis/dto/ScoredManualChunk.java
+++ b/src/main/java/com/aicsassistant/analysis/dto/ScoredManualChunk.java
@@ -1,0 +1,4 @@
+package com.aicsassistant.analysis.dto;
+
+public record ScoredManualChunk(RetrievedManualChunkDto chunk, double score) {
+}

--- a/src/main/java/com/aicsassistant/analysis/infra/ManualChunkRetrievalRepository.java
+++ b/src/main/java/com/aicsassistant/analysis/infra/ManualChunkRetrievalRepository.java
@@ -1,0 +1,182 @@
+package com.aicsassistant.analysis.infra;
+
+import com.aicsassistant.analysis.dto.RetrievedManualChunkDto;
+import com.aicsassistant.analysis.dto.ScoredManualChunk;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * RAG 검색 전용 read-only repository.
+ *
+ * <p>pgvector(`&lt;=&gt;`)와 pg_trgm(`&lt;%`, `&lt;&lt;-&gt;`) PostgreSQL 확장 연산자를 사용하므로
+ * raw SQL을 JdbcTemplate으로 직접 실행한다. 호출자는 service 레이어에서
+ * {@code @Transactional(readOnly = true)} 안에서 호출해야 한다 — keyword 검색은
+ * {@code SET LOCAL pg_trgm.word_similarity_threshold}에 의존하기 때문.
+ */
+@Repository
+@RequiredArgsConstructor
+public class ManualChunkRetrievalRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public boolean hasActiveEmbeddings() {
+        Boolean exists = jdbcTemplate.queryForObject("""
+                select exists (
+                    select 1
+                    from manual_chunk mc
+                    join manual_document md on md.id = mc.manual_document_id
+                    where md.active = true
+                      and mc.active = true
+                      and mc.embedding is not null
+                )
+                """, Boolean.class);
+        return Boolean.TRUE.equals(exists);
+    }
+
+    public List<ScoredManualChunk> findVectorCandidates(List<Double> queryEmbedding, int limit) {
+        String vectorLiteral = toVectorLiteral(queryEmbedding);
+        return jdbcTemplate.query("""
+                select
+                    mc.id,
+                    mc.manual_document_id,
+                    md.title as manual_document_title,
+                    md.category as manual_document_category,
+                    mc.chunk_index,
+                    mc.document_version,
+                    mc.token_count,
+                    mc.content,
+                    (1 - (mc.embedding <=> cast(? as vector))) as score
+                from manual_chunk mc
+                join manual_document md on md.id = mc.manual_document_id
+                where md.active = true
+                  and mc.active = true
+                  and mc.embedding is not null
+                order by mc.embedding <=> cast(? as vector), mc.id
+                limit ?
+                """, scoredChunkRowMapper(), vectorLiteral, vectorLiteral, limit);
+    }
+
+    /**
+     * pg_trgm 기반 키워드 후보 검색. cleanedQuery는 호출자가 비즈니스 전처리를 마친 텍스트여야 한다.
+     *
+     * <p>{@code SET LOCAL pg_trgm.word_similarity_threshold}는 호출 트랜잭션 스코프 + 동일 connection
+     * 안에서만 유효하므로 {@link Propagation#MANDATORY}로 호출자 트랜잭션을 강제한다 — 트랜잭션 없이
+     * 호출되면 {@code execute(SET LOCAL)}과 후속 {@code query}가 서로 다른 connection을 잡아 임계값이
+     * silent하게 무력화되는 사고를 막는다. {@code <%} operator의 임계값과 {@code <<->} distance 정렬이
+     * 함께 동작한다 ({@code gin_trgm_ops} GIN 인덱스 활용).
+     */
+    @Transactional(propagation = Propagation.MANDATORY, readOnly = true)
+    public List<ScoredManualChunk> findKeywordCandidates(String cleanedQuery, double threshold, int limit) {
+        jdbcTemplate.execute("set local pg_trgm.word_similarity_threshold = " + threshold);
+        return jdbcTemplate.query("""
+                select
+                    mc.id,
+                    mc.manual_document_id,
+                    md.title as manual_document_title,
+                    md.category as manual_document_category,
+                    mc.chunk_index,
+                    mc.document_version,
+                    mc.token_count,
+                    mc.content,
+                    word_similarity(cast(? as text), mc.content) as score
+                from manual_chunk mc
+                join manual_document md on md.id = mc.manual_document_id
+                where md.active = true
+                  and mc.active = true
+                  and cast(? as text) <% mc.content
+                order by cast(? as text) <<-> mc.content, mc.id
+                limit ?
+                """, scoredChunkRowMapper(), cleanedQuery, cleanedQuery, cleanedQuery, limit);
+    }
+
+    /**
+     * 주어진 chunk id들에 대한 실제 vector cosine similarity를 한 번에 계산한다.
+     * keyword 후보가 vector top-K 밖일 때 hybrid gate가 vectorScore 0.0으로 탈락시키는 것을 막기 위함.
+     */
+    public Map<Long, Double> findVectorScoresByIds(List<Long> ids, List<Double> queryEmbedding) {
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        String placeholders = ids.stream().map(id -> "?").collect(Collectors.joining(","));
+        String vectorLiteral = toVectorLiteral(queryEmbedding);
+
+        Object[] params = new Object[ids.size() + 1];
+        params[0] = vectorLiteral;
+        for (int i = 0; i < ids.size(); i++) {
+            params[i + 1] = ids.get(i);
+        }
+
+        Map<Long, Double> scores = new HashMap<>();
+        jdbcTemplate.query("""
+                select id, (1 - (embedding <=> cast(? as vector))) as score
+                from manual_chunk
+                where id in (%s) and embedding is not null
+                """.formatted(placeholders),
+                rs -> { scores.put(rs.getLong("id"), rs.getDouble("score")); },
+                params);
+        return scores;
+    }
+
+    public List<RetrievedManualChunkDto> findFallbackTopK(int limit) {
+        return jdbcTemplate.query("""
+                select
+                    mc.id,
+                    mc.manual_document_id,
+                    md.title as manual_document_title,
+                    md.category as manual_document_category,
+                    mc.chunk_index,
+                    mc.document_version,
+                    mc.token_count,
+                    mc.content
+                from manual_chunk mc
+                join manual_document md on md.id = mc.manual_document_id
+                where md.active = true
+                  and mc.active = true
+                order by mc.id, mc.chunk_index
+                limit ?
+                """, fallbackRowMapper(), limit);
+    }
+
+    private RowMapper<ScoredManualChunk> scoredChunkRowMapper() {
+        return (rs, rowNum) -> {
+            RetrievedManualChunkDto chunk = new RetrievedManualChunkDto(
+                    rs.getLong("id"),
+                    rs.getLong("manual_document_id"),
+                    rs.getString("manual_document_title"),
+                    rs.getString("manual_document_category"),
+                    rs.getInt("chunk_index"),
+                    rs.getInt("document_version"),
+                    rs.getInt("token_count"),
+                    rs.getString("content")
+            );
+            return new ScoredManualChunk(chunk, rs.getDouble("score"));
+        };
+    }
+
+    private RowMapper<RetrievedManualChunkDto> fallbackRowMapper() {
+        return (rs, rowNum) -> new RetrievedManualChunkDto(
+                rs.getLong("id"),
+                rs.getLong("manual_document_id"),
+                rs.getString("manual_document_title"),
+                rs.getString("manual_document_category"),
+                rs.getInt("chunk_index"),
+                rs.getInt("document_version"),
+                rs.getInt("token_count"),
+                rs.getString("content")
+        );
+    }
+
+    private String toVectorLiteral(List<Double> vector) {
+        return vector.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(",", "[", "]"));
+    }
+}


### PR DESCRIPTION
## Summary
- `ManualRetrievalService`가 `JdbcTemplate`을 service 레이어에서 직접 사용하던 부분을 infra 레이어 `@Repository`로 분리 → CLAUDE.md의 "JdbcTemplate은 복잡한 집계 쿼리에 한해 서비스 레이어에서만 사용" 룰 준수
- 신규 `analysis/infra/ManualChunkRetrievalRepository` — RAG 쿼리 5종 (`hasActiveEmbeddings`, `findVectorCandidates`, `findKeywordCandidates`, `findVectorScoresByIds`, `findFallbackTopK`)
- 신규 `analysis/dto/ScoredManualChunk` — 청크 + 점수 묶음 record (이전 service의 private `Candidate` 승격)
- 키워드 검색의 `SET LOCAL pg_trgm.word_similarity_threshold` 정합성을 위해 `findKeywordCandidates`에 `@Transactional(propagation = MANDATORY, readOnly = true)` 가드 — 호출자 트랜잭션 없으면 다른 connection에서 silent failure 발생할 위험 방지
- pgvector(`<=>`)/pg_trgm(`<%`, `<<->`) 연산자는 raw SQL 유지 — JPA로 가도 native query라 이득 없음, QueryDSL은 dialect 작업까지 들어가 오버킬

## Test plan
- [x] `compileJava` / `compileTestJava` PASS
- [x] `SearchManualToolTest`, `InquiryAgentServiceTest` (단위) PASS
- [x] `ManualRetrievalEvaluationTest` (Testcontainers + pgvector) PASS — RAG Recall@3 / MRR / hard 케이스 / P1 회귀 케이스 모두 통과, 검색 동작 회귀 없음 확인