### PR TITLE
Reply 흐름 비동기화 (event + 202 Accepted + polling)

### DIFF
--- a/src/main/java/com/aicsassistant/analysis/application/InquiryAnalysisEventListener.java
+++ b/src/main/java/com/aicsassistant/analysis/application/InquiryAnalysisEventListener.java
@@ -1,5 +1,6 @@
 package com.aicsassistant.analysis.application;
 
+import com.aicsassistant.inquiry.application.CustomerReplyEvent;
 import com.aicsassistant.inquiry.application.InquiryCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,17 @@ public class InquiryAnalysisEventListener {
             inquiryAnalysisService.analyze(event.inquiryId());
         } catch (Exception e) {
             log.error("[자동 분석] 실패 inquiryId={}", event.inquiryId(), e);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCustomerReply(CustomerReplyEvent event) {
+        log.info("[재분석] 고객 답변 감지 inquiryId={}", event.inquiryId());
+        try {
+            inquiryAnalysisService.analyze(event.inquiryId());
+        } catch (Exception e) {
+            log.error("[재분석] 실패 inquiryId={}", event.inquiryId(), e);
         }
     }
 }

--- a/src/main/java/com/aicsassistant/common/config/AsyncConfig.java
+++ b/src/main/java/com/aicsassistant/common/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.aicsassistant.common.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * {@code @Async} 실행기 설정.
+ *
+ * <p>기본 {@code SimpleAsyncTaskExecutor}는 새 스레드를 무한정 생성하고 종료 시 대기하지 않아
+ * 운영 환경에서 위험하다. 백그라운드 agent 호출이 한 번에 몰려도 폭주하지 않도록 bounded pool로
+ * 교체하고, 앱 종료 시 진행 중인 작업이 끝날 때까지 기다리도록 설정한다.
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(8);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("agent-async-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/aicsassistant/common/config/WebClientConfig.java
+++ b/src/main/java/com/aicsassistant/common/config/WebClientConfig.java
@@ -2,11 +2,9 @@ package com.aicsassistant.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
-@EnableAsync
 public class WebClientConfig {
 
     @Bean

--- a/src/main/java/com/aicsassistant/inquiry/api/InquiryMessageController.java
+++ b/src/main/java/com/aicsassistant/inquiry/api/InquiryMessageController.java
@@ -1,9 +1,8 @@
 package com.aicsassistant.inquiry.api;
 
-import com.aicsassistant.analysis.application.InquiryAnalysisService;
-import com.aicsassistant.analysis.dto.InquiryAnalysisResponse;
 import com.aicsassistant.inquiry.application.InquiryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,20 +15,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class InquiryMessageController {
 
     private final InquiryService inquiryService;
-    private final InquiryAnalysisService analysisService;
 
     record CustomerReplyRequest(String content) {}
 
     /**
-     * 고객이 AI 추가 질문에 답변을 달면 에이전트가 대화 히스토리와 함께 재실행된다.
-     * 메시지 저장과 분석은 의도적으로 별도 트랜잭션 (LLM 호출 동안 DB 락을 잡지 않기 위함).
+     * 고객이 AI 추가 질문(PENDING_CUSTOMER)에 답변을 제출한다.
+     *
+     * <p>메시지 저장만 동기로 처리하고 즉시 {@code 202 Accepted}로 응답한다.
+     * 이어지는 agent 재실행은 {@code CustomerReplyEvent} 리스너에서 비동기로 진행되며,
+     * 클라이언트는 {@code GET /api/inquiries/{id}} 폴링으로 status 변화를 감지한다.
      */
     @PostMapping("/{id}/messages")
-    public InquiryAnalysisResponse reply(
+    public ResponseEntity<Void> reply(
             @PathVariable Long id,
             @RequestBody CustomerReplyRequest request
     ) {
         inquiryService.replyAsCustomer(id, request.content());
-        return analysisService.analyze(id);
+        return ResponseEntity.accepted().build();
     }
 }

--- a/src/main/java/com/aicsassistant/inquiry/application/CustomerReplyEvent.java
+++ b/src/main/java/com/aicsassistant/inquiry/application/CustomerReplyEvent.java
@@ -1,0 +1,10 @@
+package com.aicsassistant.inquiry.application;
+
+/**
+ * 고객이 AI의 추가 질문(PENDING_CUSTOMER)에 답변을 달았을 때 발행되는 이벤트.
+ *
+ * <p>이벤트 리스너에서 비동기로 agent를 재실행한다. HTTP 요청은 이벤트 발행 후
+ * 즉시 202 Accepted로 응답하고, 클라이언트는 inquiry 상세 폴링으로 결과를 확인한다.
+ */
+public record CustomerReplyEvent(Long inquiryId) {
+}

--- a/src/main/java/com/aicsassistant/inquiry/application/InquiryService.java
+++ b/src/main/java/com/aicsassistant/inquiry/application/InquiryService.java
@@ -88,9 +88,11 @@ public class InquiryService {
     }
 
     /**
-     * 고객이 AI의 추가 질문에 답변을 다는 유스케이스. 상태 검증 + 메시지 저장만 책임지며,
-     * 이어지는 재분석은 호출자(컨트롤러)가 별도 트랜잭션에서 트리거한다 — LLM 호출이 길어
-     * 같은 트랜잭션에 묶으면 DB 락이 길어지기 때문.
+     * 고객이 AI의 추가 질문에 답변을 다는 유스케이스.
+     *
+     * <p>상태 검증 + 메시지 저장 후 {@link CustomerReplyEvent}를 발행한다. 이어지는 agent
+     * 재실행은 트랜잭션 커밋 후 별도 비동기 스레드에서 일어나므로, HTTP 요청은 메시지 저장 직후
+     * 즉시 반환되어 LLM 호출 시간만큼 HTTP 커넥션을 잡고 있지 않는다.
      */
     @Transactional
     public void replyAsCustomer(Long id, String content) {
@@ -103,6 +105,7 @@ public class InquiryService {
             throw new ApiException(HttpStatus.BAD_REQUEST, "EMPTY_CONTENT", "답변 내용을 입력해 주세요.");
         }
         inquiryMessageRepository.save(InquiryMessage.of(id, InquiryMessageRole.CUSTOMER, content.strip()));
+        eventPublisher.publishEvent(new CustomerReplyEvent(id));
     }
 
     private Inquiry getInquiryEntity(Long id) {

--- a/src/main/resources/templates/inquiries/detail.html
+++ b/src/main/resources/templates/inquiries/detail.html
@@ -303,7 +303,25 @@
                 const err = await res.json().catch(() => ({}));
                 throw new Error(err.message || `전송 실패 (${res.status})`);
             }
-            window.location.reload();
+            // 백엔드가 202 Accepted로 즉시 응답하므로 상태가 PENDING_CUSTOMER에서 벗어날 때까지 폴링한다.
+            btn.textContent = '분석 중...';
+            const started = Date.now();
+            const poll = setInterval(async () => {
+                try {
+                    const r = await fetch(`/api/inquiries/${inquiryId}`);
+                    if (!r.ok) return;
+                    const data = await r.json();
+                    if (data.status !== 'PENDING_CUSTOMER') {
+                        clearInterval(poll);
+                        window.location.reload();
+                    } else if (Date.now() - started > 60_000) {
+                        clearInterval(poll);
+                        showReplyError('분석이 지연되고 있습니다. 잠시 후 새로고침해 주세요.');
+                        btn.disabled = false;
+                        btn.textContent = '답변 보내기';
+                    }
+                } catch (_) { /* 무시 */ }
+            }, 3000);
         } catch (e) {
             showReplyError(e.message);
             btn.disabled = false;

--- a/src/test/java/com/aicsassistant/inquiry/application/InquiryServiceReplyTest.java
+++ b/src/test/java/com/aicsassistant/inquiry/application/InquiryServiceReplyTest.java
@@ -1,0 +1,94 @@
+package com.aicsassistant.inquiry.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aicsassistant.analysis.infra.InquiryAnalysisLogRepository;
+import com.aicsassistant.common.exception.ApiException;
+import com.aicsassistant.inquiry.domain.Inquiry;
+import com.aicsassistant.inquiry.domain.InquiryStatus;
+import com.aicsassistant.inquiry.infra.InquiryMessageRepository;
+import com.aicsassistant.inquiry.infra.InquiryRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * 비동기 reply 흐름에서 가장 중요한 계약 — {@link InquiryService#replyAsCustomer}가
+ * CustomerReplyEvent를 publish하는지 — 를 잠근다.
+ */
+@ExtendWith(MockitoExtension.class)
+class InquiryServiceReplyTest {
+
+    @Mock InquiryRepository inquiryRepository;
+    @Mock InquiryAnalysisLogRepository inquiryAnalysisLogRepository;
+    @Mock InquiryMessageRepository inquiryMessageRepository;
+    @Mock ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks InquiryService service;
+
+    @Test
+    void publishesCustomerReplyEvent_whenInquiryInPendingCustomer() {
+        Inquiry inquiry = Inquiry.create("cust-1", "title", "content");
+        inquiry.askFollowUp();  // → PENDING_CUSTOMER
+        when(inquiryRepository.findById(1L)).thenReturn(Optional.of(inquiry));
+
+        service.replyAsCustomer(1L, "ORD-20260101-001 입니다");
+
+        // 메시지가 저장된다
+        verify(inquiryMessageRepository, times(1)).save(any());
+        // 그리고 CustomerReplyEvent가 발행된다 (해당 inquiryId로)
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher, times(1)).publishEvent(captor.capture());
+        assertThat(captor.getValue())
+                .isInstanceOfSatisfying(CustomerReplyEvent.class,
+                        e -> assertThat(e.inquiryId()).isEqualTo(1L));
+    }
+
+    @Test
+    void rejects_whenInquiryNotInPendingCustomer() {
+        Inquiry inquiry = Inquiry.create("cust-1", "title", "content");  // 기본 NEW
+        assertThat(inquiry.getStatus()).isEqualTo(InquiryStatus.NEW);
+        when(inquiryRepository.findById(1L)).thenReturn(Optional.of(inquiry));
+
+        assertThatThrownBy(() -> service.replyAsCustomer(1L, "응답"))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("PENDING_CUSTOMER");
+
+        verify(inquiryMessageRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void rejects_whenContentBlank() {
+        Inquiry inquiry = Inquiry.create("cust-1", "title", "content");
+        inquiry.askFollowUp();
+        when(inquiryRepository.findById(1L)).thenReturn(Optional.of(inquiry));
+
+        assertThatThrownBy(() -> service.replyAsCustomer(1L, "   "))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("답변 내용");
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void rejects_whenInquiryNotFound() {
+        when(inquiryRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.replyAsCustomer(99L, "응답"))
+                .isInstanceOf(ApiException.class);
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+}


### PR DESCRIPTION
Closes #34

## 배경
- Create 흐름은 이미 `ApplicationEventPublisher` + `InquiryAnalysisEventListener`로 비동기 처리 중
- Reply 흐름은 `InquiryMessageController.reply()`에서 `analysisService.analyze(id)`를 직접 호출 → LLM 8 스텝 동안 HTTP 요청이 10~30초 블로킹
- 유저 포털 프론트엔드는 이미 polling 패턴으로 설계돼 있어 응답 body를 무시 — 202 전환은 **비파괴적**

## 변경

### 핵심 이벤트 흐름
| 항목 | Before | After |
|---|---|---|
| `POST /api/inquiries/{id}/messages` 응답 시간 | LLM 8 스텝 동안 블로킹 | 메시지 저장 후 즉시 202 Accepted |
| 분석 실행 위치 | 요청 스레드 | `@Async` 백그라운드 + `@TransactionalEventListener(AFTER_COMMIT)` |
| 클라이언트 패턴 | sync 응답 (body 무시) | `GET /api/inquiries/{id}` polling (이미 구현돼 있음) |

신규/변경:
- `CustomerReplyEvent` (record, `InquiryCreatedEvent`와 동일 패턴)
- `InquiryAnalysisEventListener.onCustomerReply` (`@Async` + AFTER_COMMIT + try/catch)
- `InquiryService.replyAsCustomer`가 메시지 저장 후 이벤트 발행
- `InquiryMessageController.reply()` → `ResponseEntity<Void>` 202

### 운영 안전 (코드 리뷰 반영)
1. **AsyncConfig 분리** — `WebClientConfig`에 끼어있던 `@EnableAsync`를 전용 `AsyncConfig`로 이동 (discoverability ↑, 의도 명시)
2. **Bounded ThreadPoolTaskExecutor** — 기본 `SimpleAsyncTaskExecutor`의 무한 스레드 생성 + 종료 시 미대기 문제를 차단
   - core 4 / max 8 / queue 50
   - `setWaitForTasksToCompleteOnShutdown(true)` + `awaitTerminationSeconds=30`
   - thread name prefix `agent-async-`
3. **상담사 어드민 detail.html polling** — 기존엔 `window.location.reload()` 즉시 호출 → 202 응답과 함께 reload 시 stale PENDING_CUSTOMER 보이는 문제 수정 (60초 timeout 가드 포함)

## 검증
- `InquiryServiceReplyTest` 신규 (4 케이스, Mockito 기반)
  - 정상 케이스: 메시지 저장 + `CustomerReplyEvent` 발행 확인
  - 상태 검증 실패 → 이벤트 미발행
  - 빈 본문 → 이벤트 미발행
  - 미존재 inquiry → 이벤트 미발행
- 전체 **103 테스트 통과** (이전 99)
- 기존 reply 통합 테스트 없었으므로 회귀 없음

## 알려진 한계 / 후속
- 분석 실패가 try/catch로 흡수돼 inquiry가 PENDING_CUSTOMER에 계속 있는 경우, 60초 polling timeout 외에 명시적 실패 신호가 없음. 향후 `inquiry_analysis_log`에 FAILED 상태를 기록하고 polling endpoint에서 노출하면 더 좋음.
- 멱등성: 동일 inquiry에 대한 중복 클릭 시 2개의 agent 호출 가능. 프론트엔드 버튼 disable + (장기적으로) 상태 전이로 가드 강화 가능.