### PR TITLE
유저 포털 분석 대기 UX: 상단 배너 → 채팅 typing 버블

### DIFF
--- a/src/main/resources/templates/user/inquiry-detail.html
+++ b/src/main/resources/templates/user/inquiry-detail.html
@@ -32,6 +32,20 @@
         .bubble.customer-bubble { background: #f5f5f5; border-radius: 12px 12px 12px 2px; }
         .bubble.ai-bubble { background: #e3f2fd; border-radius: 12px 12px 2px 12px; }
 
+        /* AI 입력 중 (메신저 스타일 typing indicator) */
+        .bubble.typing { display: inline-flex; gap: 5px; align-items: center; padding: 12px 16px; }
+        .bubble.typing .dot {
+            width: 7px; height: 7px; border-radius: 50%;
+            background: #1976d2; opacity: 0.4;
+            animation: typing-bounce 1.4s infinite ease-in-out;
+        }
+        .bubble.typing .dot:nth-child(2) { animation-delay: 0.15s; }
+        .bubble.typing .dot:nth-child(3) { animation-delay: 0.30s; }
+        @keyframes typing-bounce {
+            0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+            30% { transform: translateY(-5px); opacity: 1; }
+        }
+
         /* 답변 입력 */
         .reply-box { border-top: 1px solid #e0e0e0; padding-top: 16px; margin-top: 4px; }
         .reply-box textarea { width: 100%; box-sizing: border-box; padding: 10px 12px; border: 1px solid #90caf9;
@@ -51,11 +65,7 @@
     </header>
 
     <!-- 상태 배너 -->
-    <div th:if="${inquiry.status.name() == 'NEW'}"
-         class="status-banner banner-reviewing">
-        <div class="spinner"></div>
-        <span>AI가 문의를 분석하고 있습니다. 잠시만 기다려 주세요.</span>
-    </div>
+    <!-- NEW 상태는 별도 배너 없이 대화 스레드 끝의 typing 버블로 표현 -->
     <div th:if="${inquiry.status.name() == 'AI_PROCESSED'}"
          class="status-banner banner-reviewing">
         <div class="spinner"></div>
@@ -106,6 +116,14 @@
                     <div class="bubble customer-bubble" th:text="${msg.getContent()}"></div>
                 </div>
             </div>
+
+            <!-- AI 입력 중 표시: 최초 분석(NEW) 시 서버 사이드로, 재분석 시 JS로 동적 추가 -->
+            <div th:if="${inquiry.status.name() == 'NEW'}" class="bubble-wrap ai">
+                <div class="bubble-avatar ai-av">AI</div>
+                <div class="bubble ai-bubble typing">
+                    <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+                </div>
+            </div>
         </div>
 
         <!-- 최종 답변: 상담사 확정(REVIEWED) 또는 종료(CLOSED) 시 finalAnswer 표시 -->
@@ -122,19 +140,7 @@
             </div>
         </div>
 
-        <!-- 전송 후 AI 대기 중 (JS로 표시) -->
-        <div id="waiting-indicator" style="display:none; margin-top:14px; padding:12px 16px;
-             background:#f5f5f5; border-radius:8px; font-size:13px; color:#888;">
-            <span class="dot-pulse">AI가 답변을 생성하고 있습니다</span>&nbsp;
-            <span id="dot-anim">...</span>
-        </div>
     </div>
-
-    <!-- NEW 상태: 폴링 안내 -->
-    <p th:if="${inquiry.status.name() == 'NEW'}"
-       style="text-align:center;font-size:13px;color:#aaa;">
-       페이지가 자동으로 갱신됩니다...
-    </p>
 </main>
 
 <script th:inline="javascript">
@@ -184,18 +190,16 @@
                 <div class="bubble customer-bubble" style="white-space:pre-wrap;">${escapeHtml(content)}</div>`;
             thread.appendChild(bubble);
 
-            // 입력창 숨기고 대기 상태로 전환
+            // 입력창 숨기고 AI typing 버블을 스레드 끝에 추가
             document.getElementById('reply-box').style.display = 'none';
-            const waiting = document.getElementById('waiting-indicator');
-            waiting.style.display = 'block';
-
-            // 점 애니메이션
-            let dots = 0;
-            const dotEl = document.getElementById('dot-anim');
-            const dotTimer = setInterval(() => {
-                dots = (dots + 1) % 4;
-                dotEl.textContent = '.'.repeat(dots || 1);
-            }, 500);
+            const typing = document.createElement('div');
+            typing.className = 'bubble-wrap ai';
+            typing.innerHTML = `
+                <div class="bubble-avatar ai-av">AI</div>
+                <div class="bubble ai-bubble typing">
+                    <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+                </div>`;
+            thread.appendChild(typing);
 
             // 폴링: 상태 변경 시 페이지 갱신
             const poll = setInterval(async () => {
@@ -205,7 +209,6 @@
                     const data = await r.json();
                     if (data.status !== 'PENDING_CUSTOMER') {
                         clearInterval(poll);
-                        clearInterval(dotTimer);
                         window.location.reload();
                     }
                 } catch (e) { /* 무시 */ }


### PR DESCRIPTION
Closes #36

## Before / After

| Before | After |
|---|---|
| 상단 배너 "AI가 문의를 분석하고 있습니다" + 스피너 | 채팅 스레드 끝의 **AI 말풍선 + 점 3개 애니메이션** |
| 하단 "페이지가 자동으로 갱신됩니다..." | (제거 — typing 버블이 자명) |
| 답변 후 별도 `#waiting-indicator` 박스 + 점 텍스트 setInterval | 동일한 typing 버블을 스레드에 동적 추가 |

## 변경 내용

- `.bubble.typing` CSS: 7px dot 3개가 staggered bounce 애니메이션 (카톡/슬랙 스타일)
- NEW 상태: 상단 분석 배너 제거 → 서버 사이드 Thymeleaf로 typing 버블 렌더
- 답변 후 재분석: JS로 동일한 typing 버블을 thread에 append (이전 `#waiting-indicator` 코드 제거)
- "페이지가 자동으로 갱신됩니다..." 텍스트 제거
- AI_PROCESSED / AUTO_ANSWERED / CLOSED 배너는 유지 (이들은 로딩이 아니라 단계 정보)

## 변경 안 한 부분 (의도)
- 상담사 어드민(`inquiries/detail.html`): 상담사는 분석 진행 단계 정보가 필요해서 배너 유지가 더 적절. 유저 포털만 메신저 UX 적용.

## 검증
- 컴파일 OK
- 시각 검증은 dev 실행 → 새 문의 등록 시 typing 버블 노출 확인 필요