### PR TITLE
유저 포털 상태 배너 정리 + 채팅 종료 라인

### DIFF
--- a/src/main/resources/templates/user/inquiry-detail.html
+++ b/src/main/resources/templates/user/inquiry-detail.html
@@ -32,6 +32,20 @@
         .bubble.customer-bubble { background: #f5f5f5; border-radius: 12px 12px 12px 2px; }
         .bubble.ai-bubble { background: #e3f2fd; border-radius: 12px 12px 2px 12px; }
 
+        /* 상담사 확정 답변 버블 — AI 자동 답변과 시각적으로 구분 */
+        .bubble-avatar.counselor-av { background: #2e7d32; color: #fff; }
+        .bubble.counselor-bubble { background: #e8f5e9; border-radius: 12px 12px 2px 12px; }
+
+        /* 대화 종료 라인 — 메신저 "오늘", "어제" 같은 separator 톤 */
+        .chat-end {
+            margin-top: 18px; padding: 6px 0;
+            text-align: center; font-size: 12px; color: #aaa;
+            display: flex; align-items: center; gap: 12px;
+        }
+        .chat-end::before, .chat-end::after {
+            content: ''; flex: 1; height: 1px; background: #e0e0e0;
+        }
+
         /* AI 입력 중 (메신저 스타일 typing indicator) */
         .bubble.typing { display: inline-flex; gap: 5px; align-items: center; padding: 12px 16px; }
         .bubble.typing .dot {
@@ -65,23 +79,12 @@
     </header>
 
     <!-- 상태 배너 -->
-    <!-- NEW 상태는 별도 배너 없이 대화 스레드 끝의 typing 버블로 표현 -->
+    <!-- 채팅 UX와 중복되는 배너(PENDING_CUSTOMER / AUTO_ANSWERED / REVIEWED / CLOSED)는
+         스레드 자체로 충분히 전달되므로 제거. NEW는 typing 버블, 종료는 chat-end 라인으로 표현. -->
     <div th:if="${inquiry.status.name() == 'AI_PROCESSED'}"
          class="status-banner banner-reviewing">
         <div class="spinner"></div>
         <span>담당자가 검토 중입니다. 순서에 따라 답변 드리겠습니다.</span>
-    </div>
-    <div th:if="${inquiry.status.name() == 'PENDING_CUSTOMER'}"
-         class="status-banner banner-pending">
-        <span>추가 정보가 필요합니다. 아래 답변을 확인하고 내용을 입력해 주세요.</span>
-    </div>
-    <div th:if="${inquiry.status.name() == 'AUTO_ANSWERED' or inquiry.status.name() == 'REVIEWED'}"
-         class="status-banner banner-answered">
-        <span>답변이 완료되었습니다.</span>
-    </div>
-    <div th:if="${inquiry.status.name() == 'CLOSED'}"
-         class="status-banner banner-closed">
-        <span>종료된 문의입니다.</span>
     </div>
 
     <!-- 문의 정보 -->
@@ -124,12 +127,24 @@
                     <span class="dot"></span><span class="dot"></span><span class="dot"></span>
                 </div>
             </div>
-        </div>
 
-        <!-- 최종 답변: 상담사 확정(REVIEWED) 또는 종료(CLOSED) 시 finalAnswer 표시 -->
-        <div th:if="${inquiry.status.name() == 'REVIEWED' or inquiry.status.name() == 'CLOSED'}"
-             style="margin-top:12px;padding:14px;background:#e8f5e9;border-radius:8px;font-size:14px;line-height:1.6;white-space:pre-wrap;"
-             th:text="${inquiry.finalAnswer}"></div>
+            <!-- 상담사 확정 답변 (REVIEWED / CLOSED) — 채팅 UX 일관성을 위해 버블로 표시 -->
+            <div th:if="${inquiry.status.name() == 'REVIEWED' or inquiry.status.name() == 'CLOSED'}"
+                 class="bubble-wrap ai">
+                <div class="bubble-avatar counselor-av">상담</div>
+                <div class="bubble counselor-bubble" th:text="${inquiry.finalAnswer}"></div>
+            </div>
+
+            <!-- 대화 종료 라인: AI 자동 답변 또는 상담사 확정 후 -->
+            <div th:if="${inquiry.status.name() == 'AUTO_ANSWERED'
+                       or inquiry.status.name() == 'REVIEWED'
+                       or inquiry.status.name() == 'CLOSED'}"
+                 class="chat-end">
+                <span th:if="${inquiry.status.name() == 'AUTO_ANSWERED'}">대화가 종료되었습니다</span>
+                <span th:if="${inquiry.status.name() == 'REVIEWED'}">상담사 답변으로 종료되었습니다</span>
+                <span th:if="${inquiry.status.name() == 'CLOSED'}">종료된 문의입니다</span>
+            </div>
+        </div>
 
         <!-- PENDING_CUSTOMER: 고객 답변 입력 -->
         <div th:if="${inquiry.status.name() == 'PENDING_CUSTOMER'}" class="reply-box" id="reply-box">


### PR DESCRIPTION
Closes #38

## 변경

| 상태 | Before | After |
|---|---|---|
| NEW | (이미 typing 버블, #36 PR에서 처리) | 그대로 |
| AI_PROCESSED | 상단 배너 "담당자가 검토 중" | **그대로 유지** (채팅으로 전달 불가한 단계 정보) |
| PENDING_CUSTOMER | 주황 배너 "추가 정보가 필요합니다" | **배너 제거** — AI 버블 + 답변 입력 박스가 안내 |
| AUTO_ANSWERED | 초록 배너 "답변이 완료되었습니다" | **배너 제거 + chat-end 라인** "대화가 종료되었습니다" |
| REVIEWED | 초록 배너 + 별도 green box | **배너 제거 + 상담사 버블 + chat-end 라인** "상담사 답변으로 종료되었습니다" |
| CLOSED | 회색 배너 "종료된 문의입니다" | **배너 제거 + chat-end 라인** "종료된 문의입니다" |

## UX 디테일

### Chat-end separator
메신저 앱의 "오늘"/"어제" separator처럼 양쪽 끝선이 있는 회색 라인:
```
─────  대화가 종료되었습니다  ─────
```

### 상담사 확정 답변 (REVIEWED/CLOSED)
기존 별도 green box → counselor 버블로 변환. AI 자동 답변(파란색 ai-bubble)과 시각적 구분 유지 (녹색 톤 counselor-bubble + 녹색 상담 아바타).

## 검증
- 빌드 OK
- 시각: dev 실행 → 각 상태 케이스 확인 필요