### PR TITLE
어드민 문의 상세 가독성: ToolResult JSON envelope 제거 + 참고 문서 빈 상태 명시

### DIFF
--- a/src/main/java/com/aicsassistant/ui/application/InquiryDetailAssembler.java
+++ b/src/main/java/com/aicsassistant/ui/application/InquiryDetailAssembler.java
@@ -72,10 +72,7 @@ public class InquiryDetailAssembler {
             default                   -> step.action();
         };
 
-        String obs = step.observation();
-        String summary = (obs != null && obs.length() > OBSERVATION_SUMMARY_MAX_LENGTH)
-                ? obs.substring(0, OBSERVATION_SUMMARY_MAX_LENGTH) + "..."
-                : obs;
+        String summary = truncate(humanizeObservation(step.observation()));
 
         List<DocRef> docs = step.referencedChunks() == null ? List.of() :
                 step.referencedChunks().stream()
@@ -86,5 +83,43 @@ public class InquiryDetailAssembler {
                                 m -> List.copyOf(m.values())));
 
         return new AgentStepView(label, step.thought(), summary, docs);
+    }
+
+    /**
+     * ToolResult JSON envelope에서 사람이 볼 부분만 추출한다.
+     *
+     * <pre>{ok:true, data:"...", errorCategory:null, isRetryable:false, errorMessage:null}</pre>
+     *
+     * <p>상담사는 envelope 메타필드를 볼 이유가 없다. 성공 시 {@code data} 본문만,
+     * 실패 시 카테고리와 메시지만 노출한다. 파싱이 안 되면 원문을 그대로 반환한다.
+     */
+    private String humanizeObservation(String observation) {
+        if (observation == null || observation.isBlank()) {
+            return observation;
+        }
+        try {
+            var node = objectMapper.readTree(observation);
+            if (!node.isObject()) {
+                return observation;
+            }
+            if (node.path("ok").asBoolean(false)) {
+                String data = node.path("data").asText("").trim();
+                return data.isEmpty() ? "(결과 없음)" : data;
+            }
+            String category = node.path("errorCategory").asText("");
+            String message = node.path("errorMessage").asText("");
+            String head = category.isEmpty() ? "실패" : category;
+            return message.isEmpty() ? "❌ " + head : "❌ " + head + ": " + message;
+        } catch (Exception e) {
+            // JSON이 아니거나 파싱 실패 — 그대로 노출
+            return observation;
+        }
+    }
+
+    private static String truncate(String text) {
+        if (text == null) return null;
+        return text.length() > OBSERVATION_SUMMARY_MAX_LENGTH
+                ? text.substring(0, OBSERVATION_SUMMARY_MAX_LENGTH) + "..."
+                : text;
     }
 }

--- a/src/main/resources/templates/inquiries/detail.html
+++ b/src/main/resources/templates/inquiries/detail.html
@@ -239,8 +239,12 @@
         <article class="card">
             <h2>참고 문서</h2>
             <p class="muted" style="font-size:13px;margin-bottom:12px;">AI가 답변 생성 시 참고한 정책 문서입니다.</p>
-            <div th:if="${#lists.isEmpty(detail.evidenceChunks)}" class="muted">
+            <!-- 분석 전: 안내 / 분석 완료 + 참조 없음: 빈 상태 명시 -->
+            <div th:if="${#lists.isEmpty(detail.evidenceChunks) and detail.inquiry.status.name() == 'NEW'}" class="muted">
                 AI 분석 완료 후 참고한 정책 문서가 표시됩니다.
+            </div>
+            <div th:if="${#lists.isEmpty(detail.evidenceChunks) and detail.inquiry.status.name() != 'NEW'}" class="muted">
+                참고한 정책 문서가 없습니다. (FAQ 또는 주문 조회로만 답변)
             </div>
             <div th:each="chunk : ${detail.evidenceChunks}" class="chunk">
                 <div class="chunk-meta">

--- a/src/test/java/com/aicsassistant/ui/application/InquiryDetailAssemblerTest.java
+++ b/src/test/java/com/aicsassistant/ui/application/InquiryDetailAssemblerTest.java
@@ -73,6 +73,54 @@ class InquiryDetailAssemblerTest {
     }
 
     @Test
+    void loadAgentSteps_extractsDataFromToolResultSuccess() {
+        String stepsJson = """
+                [{"thought":"t","action":"search_faq","actionInput":"{}",
+                  "observation":"{\\"ok\\":true,\\"data\\":\\"Q: 회원 탈퇴는 어떻게 하나요?\\\\nA: 마이페이지에서...\\",\\"errorCategory\\":null,\\"isRetryable\\":false,\\"errorMessage\\":null}",
+                  "referencedChunks":[]}]
+                """;
+        when(analysisLogService.getLatestAgentStepsJson(1L)).thenReturn(Optional.of(stepsJson));
+
+        List<AgentStepView> steps = assembler.loadAgentSteps(1L);
+
+        assertThat(steps).hasSize(1);
+        String summary = steps.get(0).observationSummary();
+        assertThat(summary)
+                .startsWith("Q: 회원 탈퇴는 어떻게 하나요?")
+                .doesNotContain("\"ok\"")
+                .doesNotContain("errorCategory");
+    }
+
+    @Test
+    void loadAgentSteps_formatsToolResultErrorAsHumanReadable() {
+        String stepsJson = """
+                [{"thought":"t","action":"check_order_status","actionInput":"{}",
+                  "observation":"{\\"ok\\":false,\\"data\\":null,\\"errorCategory\\":\\"NOT_FOUND\\",\\"isRetryable\\":false,\\"errorMessage\\":\\"주문을 찾을 수 없습니다\\"}",
+                  "referencedChunks":[]}]
+                """;
+        when(analysisLogService.getLatestAgentStepsJson(1L)).thenReturn(Optional.of(stepsJson));
+
+        List<AgentStepView> steps = assembler.loadAgentSteps(1L);
+
+        assertThat(steps.get(0).observationSummary())
+                .isEqualTo("❌ NOT_FOUND: 주문을 찾을 수 없습니다");
+    }
+
+    @Test
+    void loadAgentSteps_keepsObservation_whenNotJson() {
+        String stepsJson = """
+                [{"thought":"t","action":"search_manual","actionInput":"{}",
+                  "observation":"그냥 평문이라 JSON 아님",
+                  "referencedChunks":[]}]
+                """;
+        when(analysisLogService.getLatestAgentStepsJson(1L)).thenReturn(Optional.of(stepsJson));
+
+        List<AgentStepView> steps = assembler.loadAgentSteps(1L);
+
+        assertThat(steps.get(0).observationSummary()).isEqualTo("그냥 평문이라 JSON 아님");
+    }
+
+    @Test
     void loadAgentSteps_dedupesReferencedChunksByDocId() {
         String stepsJson = """
                 [


### PR DESCRIPTION
Closes #40

## 배경 (실제 데이터 검증)

DB 직접 확인 결과:
\`\`\`
id 13: retrieved_chunk_ids = "7"      ← 청크 있음 (UI에서 정상 표시)
id 14: retrieved_chunk_ids = ""        ← search_manual 호출했지만 0건 매치
id 15: retrieved_chunk_ids = ""        ← 동일
id 17: retrieved_chunk_ids = ""        ← search_faq만 호출 (search_manual 미호출)
\`\`\`

UI 버그가 아니라 **사용자에게 상태가 전달되지 않은 문제** — 분석 완료 후에도 placeholder ("AI 분석 완료 후 표시됩니다")가 그대로 노출돼 "UI 버그인가?" 오해 유발.

또한 AI 분석 과정의 observation이 raw JSON envelope로 노출돼 상담사에게 노이즈:
\`{"ok":true,"data":"Q: 회원 탈퇴는...","errorCategory":null,"isRetryable":false,"errorMessage":null}\`

## 변경

### 1. \`InquiryDetailAssembler.humanizeObservation\` 신규
ToolResult JSON envelope 파싱해서 사람이 볼 부분만 추출:

| Envelope | 변환 후 |
|---|---|
| \`{"ok":true,"data":"Q: 회원 탈퇴는 어떻게...","errorCategory":null,...}\` | \`Q: 회원 탈퇴는 어떻게...\` |
| \`{"ok":false,"data":null,"errorCategory":"NOT_FOUND","errorMessage":"주문을 찾을 수 없습니다"}\` | \`❌ NOT_FOUND: 주문을 찾을 수 없습니다\` |
| 비-JSON 평문 | 원문 그대로 |

200자 truncation은 정제된 텍스트 기준으로 적용.

### 2. 참고 문서 섹션 빈 상태 분기
| 상태 | 메시지 |
|---|---|
| 분석 전 (NEW) | "AI 분석 완료 후 참고한 정책 문서가 표시됩니다." (기존 유지) |
| 분석 완료 + 청크 없음 | **"참고한 정책 문서가 없습니다. (FAQ 또는 주문 조회로만 답변)"** (신규) |
| 분석 완료 + 청크 있음 | 청크 목록 (기존 유지) |

### 3. 단위 테스트 3 케이스 추가 (InquiryDetailAssemblerTest)
- 성공 envelope에서 data만 추출
- 실패 envelope을 "❌ category: message" 형식으로 변환
- 비-JSON observation은 원문 보존

## 검증
- 전체 **106 테스트 통과** (이전 103)
- DB 데이터 변경 없음 — 표시 로직만 개선

## 후속 (이번 PR 범위 외)
- 분석 완료 후에도 청크가 잡히지 않는 케이스가 많은 경우, hybrid 검색의 vector floor 임계값을 재조정하거나 카테고리 필터 강화로 더 많은 매뉴얼을 hit하게 할 수 있음.