### PR TITLE
AI_PROCESSED 상태: 상단 배너 → 상담사 typing 버블

### DIFF
--- a/src/main/resources/templates/user/inquiry-detail.html
+++ b/src/main/resources/templates/user/inquiry-detail.html
@@ -53,6 +53,8 @@
             background: #1976d2; opacity: 0.4;
             animation: typing-bounce 1.4s infinite ease-in-out;
         }
+        /* 상담사 typing은 dot 색만 다르게 (counselor 톤 = 녹색) */
+        .bubble.counselor-bubble.typing .dot { background: #2e7d32; }
         .bubble.typing .dot:nth-child(2) { animation-delay: 0.15s; }
         .bubble.typing .dot:nth-child(3) { animation-delay: 0.30s; }
         @keyframes typing-bounce {
@@ -78,14 +80,12 @@
         <a class="button ghost" th:href="@{/app/home}">내 문의 목록</a>
     </header>
 
-    <!-- 상태 배너 -->
-    <!-- 채팅 UX와 중복되는 배너(PENDING_CUSTOMER / AUTO_ANSWERED / REVIEWED / CLOSED)는
-         스레드 자체로 충분히 전달되므로 제거. NEW는 typing 버블, 종료는 chat-end 라인으로 표현. -->
-    <div th:if="${inquiry.status.name() == 'AI_PROCESSED'}"
-         class="status-banner banner-reviewing">
-        <div class="spinner"></div>
-        <span>담당자가 검토 중입니다. 순서에 따라 답변 드리겠습니다.</span>
-    </div>
+    <!-- 모든 상태를 스레드 내부의 채팅 요소로 표현 (상단 배너 없음):
+         NEW         → AI typing 버블
+         AI_PROCESSED → 상담사 typing 버블
+         PENDING_CUSTOMER → AI 추가 질문 버블 + 답변 입력
+         AUTO_ANSWERED / REVIEWED / CLOSED → 결과 버블 + chat-end 라인 -->
+
 
     <!-- 문의 정보 -->
     <div class="meta-row">
@@ -120,10 +120,18 @@
                 </div>
             </div>
 
-            <!-- AI 입력 중 표시: 최초 분석(NEW) 시 서버 사이드로, 재분석 시 JS로 동적 추가 -->
+            <!-- AI 입력 중: 최초 분석(NEW) 시 서버 사이드로, 재분석 시 JS로 동적 추가 -->
             <div th:if="${inquiry.status.name() == 'NEW'}" class="bubble-wrap ai">
                 <div class="bubble-avatar ai-av">AI</div>
                 <div class="bubble ai-bubble typing">
+                    <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+                </div>
+            </div>
+
+            <!-- 상담사 검토 중: AI_PROCESSED 상태에서 사람 검토를 명시 -->
+            <div th:if="${inquiry.status.name() == 'AI_PROCESSED'}" class="bubble-wrap ai">
+                <div class="bubble-avatar counselor-av">상담</div>
+                <div class="bubble counselor-bubble typing">
                     <span class="dot"></span><span class="dot"></span><span class="dot"></span>
                 </div>
             </div>
@@ -162,13 +170,15 @@
     const inquiryId = /*[[${inquiry.id}]]*/ 0;
     const inquiryStatus = /*[[${inquiry.status.name()}]]*/ '';
 
-    if (inquiryStatus === 'NEW') {
+    // typing 상태(NEW: AI 분석 중 / AI_PROCESSED: 상담사 검토 중)에서 상태 변화 폴링
+    if (inquiryStatus === 'NEW' || inquiryStatus === 'AI_PROCESSED') {
+        const initialStatus = inquiryStatus;
         const poll = setInterval(async () => {
             try {
                 const res = await fetch(`/api/inquiries/${inquiryId}`);
                 if (!res.ok) return;
                 const data = await res.json();
-                if (data.status !== 'NEW') {
+                if (data.status !== initialStatus) {
                     clearInterval(poll);
                     window.location.reload();
                 }


### PR DESCRIPTION
Closes #42

## Before / After

| 상태 | Before | After |
|---|---|---|
| NEW | AI typing 버블 | (그대로) |
| **AI_PROCESSED** | **상단 배너 + 스피너** | **상담사 typing 버블** (counselor 녹색 dot) |
| PENDING_CUSTOMER | AI 버블 + 입력 박스 | (그대로) |
| AUTO_ANSWERED/REVIEWED/CLOSED | 결과 버블 + chat-end | (그대로) |

이제 **상단 배너 0개** — 모든 상태가 채팅 스레드 내부에서 자기설명.

## 핵심 디테일
- AI typing dot 색(`#1976d2` 파랑) vs 상담사 typing dot 색(`#2e7d32` 녹색)으로 누가 응답 중인지 시각 구분
- AI 자동 답변 vs 상담사 확정 답변과 일관된 톤 (파랑 / 녹색)
- polling JS: NEW + AI_PROCESSED 모두 감지하도록 확장 (`initialStatus` 캡처)

## 설계 결정 — 상담사 답변을 별도 entity로 명시한 이유
1. 신뢰: 사람이 검토했다는 게 명시되면 환불/불만 케이스에서 만족도 ↑
2. 톤 기대치: AI 답변과 상담사 답변에 다른 뉘앙스 기대 가능
3. 업계 표준: 카카오톡 상담, 네이버 톡톡 모두 상담사 프로필 명시
4. 정직성: AI인 척하지 않음 (특히 그룹웨어 도메인에서 중요)